### PR TITLE
debug indexing error in multiplane.py

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -61,6 +61,6 @@ jobs:
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/coverage.xml
         fail_ci_if_error: true
-        version: "v0.1.15"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,3 +63,4 @@ jobs:
       with:
         files: ${{ github.workspace }}/coverage.xml
         fail_ci_if_error: true
+        version: "v0.1.15"

--- a/src/caustic/lenses/multiplane.py
+++ b/src/caustic/lenses/multiplane.py
@@ -50,13 +50,13 @@ class MultiplaneLens(ThickLens):
         X_i = kwargs.get("_X_i", (D_0_i * thx, D_0_i * thy))
 
         # Compute the alphas at the next plane
-        alphas = lenses[i].alpha(
+        alphas = lenses[idxs[i]].alpha(
             X_i[0] / D_0_i,
             X_i[1] / D_0_i,
             z_ls_sorted[i],
             z_ls_sorted[i + 1] if i + 1 < len(z_ls) else z_s,
             cosmology,
-            *lens_args[i],
+            *lens_args[idxs[i]],
         )
         X_ip1 = (
             (D_i_ip1 / D_im1_i + 1) * X_i[0]


### PR DESCRIPTION
Indexing erroneously assumed the lenses were sorted by redshift, now they are accessed in the correct order.