### PR TITLE
Update Kappa Grid fft and dtype behavior

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,12 +18,6 @@ jobs:
     - name: Checkout caustic
       uses: actions/checkout@v3
 
-    - name: Checkout torchinterp1d
-      uses: actions/checkout@v3
-      with:
-        repository: aliutkus/torchinterp1d
-        path: torchinterp1d
-
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
@@ -40,10 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov torch
-        # Install torchinterp1d
-        cd $GITHUB_WORKSPACE/torchinterp1d
-        pip install .
-        # Install other deps
+        # Install deps
         cd $GITHUB_WORKSPACE
         pip install -r requirements.txt
       shell: bash

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,7 +45,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         pip install --upgrade pip
         pip --version
-        pip install torch torchvision
+        pip install torch==1.13.1
         pip show torch
         pip install pytest
         # Install torchinterp1d

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,12 +7,12 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
-
-permissions:
-  contents: read
+      - dev
+  workflow_dispatch:
 
 jobs:
   build:
@@ -26,8 +26,6 @@ jobs:
     steps:
     - name: Checkout caustic
       uses: actions/checkout@v3
-      with:
-        path: caustic
 
     - name: Checkout torchinterp1d
       uses: actions/checkout@v3
@@ -39,11 +37,19 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Record State
+      run: |
+        pwd
+        echo github.ref is: ${{ github.ref }}
+        echo GITHUB_SHA is: $GITHUB_SHA
+        echo github.event_name is: ${{ github.event_name }}
+        echo github workspace: ${{ github.workspace }}
+        pip --version
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest torch
+        pip install pytest pytest-cov torch
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d
         pip install .
@@ -52,10 +58,11 @@ jobs:
         pip install -r requirements.txt
       shell: bash
 
-    - name: Install caustic
+    - name: Install Caustic
       run: |
-        cd $GITHUB_WORKSPACE/caustic
-        pip install .
+        cd $GITHUB_WORKSPACE
+        pip install -e .
+        pip show caustic
       shell: bash
 
     - name: Test with pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,12 +27,6 @@ jobs:
     - name: Checkout caustic
       uses: actions/checkout@v3
 
-    - name: Checkout torchinterp1d
-      uses: actions/checkout@v3
-      with:
-        repository: aliutkus/torchinterp1d
-        path: torchinterp1d
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -50,10 +44,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov torch
-        # Install torchinterp1d
-        cd $GITHUB_WORKSPACE/torchinterp1d
-        pip install .
-        # Install other deps
+        # Install deps
         cd $GITHUB_WORKSPACE
         pip install -r requirements.txt
       shell: bash

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        cd $GITHUB_WORKSPACE/caustic
+        cd $GITHUB_WORKSPACE
         pytest test
       shell: bash
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,7 +46,12 @@ jobs:
         pip install --upgrade pip
         pip --version
         pip install torch==1.13.1
+        echo xxxx
         pip show torch
+        echo xxxxx
+        python -c "import sys; print('Python executable:', sys.executable)"
+        echo xxxxxx
+        python --version
         pip install pytest
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,10 +44,11 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         pip install --upgrade pip
-        pip install pytest torch
+        pip install torch torchvision
+        pip install pytest
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d
-        pip install .
+        pip install -e .
         # Install other deps
         cd $GITHUB_WORKSPACE/caustic
         pip install -r requirements.txt

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,7 +44,9 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         pip install --upgrade pip
+        pip --version
         pip install torch torchvision
+        pip show torch
         pip install pytest
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,24 +42,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cd $GITHUB_WORKSPACE
-        pip install --upgrade pip
-        pip --version
-        pip install torch==1.13.1
-        echo xxx
-        pip show torch
-        echo xxxx
-        python -c "import sys; print('Python executable:', sys.executable)"
-        echo xxxxx
-        python --version
-        echo xxxxxx
-        python -c "import torch; print('Torch version:', torch.__version__)"
-        pip install pytest
+        python -m pip install --upgrade pip
+        pip install pytest torch
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d
-        pip install -e .
+        pip install .
         # Install other deps
-        cd $GITHUB_WORKSPACE/caustic
+        cd $GITHUB_WORKSPACE
         pip install -r requirements.txt
       shell: bash
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,12 +46,14 @@ jobs:
         pip install --upgrade pip
         pip --version
         pip install torch==1.13.1
-        echo xxxx
+        echo xxx
         pip show torch
-        echo xxxxx
+        echo xxxx
         python -c "import sys; print('Python executable:', sys.executable)"
-        echo xxxxxx
+        echo xxxxx
         python --version
+        echo xxxxxx
+        python -c "import torch; print('Torch version:', torch.__version__)"
         pip install pytest
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd $GITHUB_WORKSPACE
-        python -m pip install --upgrade pip
+        pip install --upgrade pip
         pip install pytest torch
         # Install torchinterp1d
         cd $GITHUB_WORKSPACE/torchinterp1d

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ some imprecise/untested calculations.
 
 ## Installation
 
-Simply install caustic from PyPI: 
+Simply install caustic from PyPI:
 ```bash
 pip install caustic
 ```

--- a/README.md
+++ b/README.md
@@ -9,14 +9,7 @@ some imprecise/untested calculations.
 
 ## Installation
 
-Manually install the [torchinterp1d](https://github.com/aliutkus/torchinterp1d)
-dependency:
-```bash
-git clone git@github.com:aliutkus/torchinterp1d.git
-cd torchinterp1d
-pip install .
-```
-Then install caustic from PyPI:
+Simply install caustic from PyPI:
 ```bash
 pip install caustic
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The lensing pipeline of the future: GPU-accelerated, automatically-differentiabl
 highly modular. Currently under heavy development: expect interface changes and
 some imprecise/untested calculations.
 
-## Installation
+## Installation 
 
 Simply install caustic from PyPI:
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ some imprecise/untested calculations.
 
 ## Installation
 
-Simply install caustic from PyPI:
+Simply install caustic from PyPI: 
 ```bash
 pip install caustic
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "numpy",
     "scipy",
     "torch",
-    "torchinterp1d"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ numpy==1.23.5
 scipy==1.8.0
 setuptools==67.2.0
 torch==2.0.0
-torchinterp1d==1.1

--- a/src/caustic/cosmology.py
+++ b/src/caustic/cosmology.py
@@ -6,8 +6,8 @@ import torch
 from astropy.cosmology import default_cosmology
 from scipy.special import hyp2f1
 from torch import Tensor
-from torchinterp1d import interp1d
 
+from .utils import interp1d
 from .constants import G_over_c2, c_Mpc_s, km_to_Mpc
 from .parametrized import Parametrized
 

--- a/src/caustic/lenses/kappa_grid.py
+++ b/src/caustic/lenses/kappa_grid.py
@@ -28,12 +28,32 @@ class KappaGrid(ThinLens):
         mode: str = "fft",
         use_next_fast_len: bool = True,
     ):
+        """Strong lensing with user provided kappa map
+
+        KappaGrid is a class for strong gravitational lensing with a
+        user-provided kappa map. It inherits from the ThinLens class.
+        This class enables the computation of deflection angles and
+        lensing potential by applying the user-provided kappa map to a
+        grid using either Fast Fourier Transform (FFT) or a 2D
+        convolution.
+
+        Attributes:
+            name (str): The name of the KappaGrid object.
+            fov (float): The field of view in arcseconds.
+            n_pix (int): The number of pixels on each side of the grid.
+            cosmology (Cosmology): An instance of the cosmological parameters.
+            z_l (Optional[Tensor]): The redshift of the lens.
+            thx0 (Optional[Tensor]): The x-coordinate of the center of the grid.
+            thy0 (Optional[Tensor]): The y-coordinate of the center of the grid.
+            kappa_map (Optional[Tensor]): A 2D tensor representing the kappa map.
+            kappa_map_shape (Optional[tuple[int, ...]]): The shape of the kappa map.
+            mode (str, optional): The convolution mode for calculating deflection angles and lensing potential.
+                It can be either "fft" (Fast Fourier Transform) or "conv2d" (2D convolution). Default is "fft".
+            use_next_fast_len (bool, optional): If True, adds additional padding to speed up the FFT by calling
+                `scipy.fft.next_fast_len`. The speed boost can be substantial when `n_pix` is prime. Default is True.
+
         """
-        Args:
-            use_next_fast_len: if true, add additional padding to speed up the FFT
-                by calling `scipy.fft.next_fast_len <https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.next_fast_len.html#scipy.fft.next_fast_len>`_.
-                The speed boost can be substantial when `n_pix` is prime.
-        """
+        
         super().__init__(name, cosmology, z_l)
 
         if kappa_map is not None and kappa_map.ndim != 2:
@@ -78,6 +98,13 @@ class KappaGrid(ThinLens):
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
     ):
+        """
+        Move the KappaGrid object and all its tensors to the specified device and dtype.
+
+        Args:
+            device (Optional[torch.device]): The target device to move the tensors to.
+            dtype (Optional[torch.dtype]): The target data type to cast the tensors to.
+        """        
         super().to(device, dtype)
         self.Psi_kernel = self.Psi_kernel.to(device=device, dtype=dtype)
         self.ax_kernel = self.ax_kernel.to(device=device, dtype=dtype)
@@ -89,24 +116,63 @@ class KappaGrid(ThinLens):
         if self.ay_kernel_tilde is not None:
             self.ay_kernel_tilde = self.ay_kernel_tilde.to(device=device, dtype=dtype)
 
-    def _fft2_padded(self, x):
+    def _fft2_padded(self, x: Tensor) -> Tensor:
+        """
+        Compute the 2D Fast Fourier Transform (FFT) of a tensor with zero-padding.
+
+        Args:
+            x (Tensor): The input tensor to be transformed.
+
+        Returns:
+            Tensor: The 2D FFT of the input tensor with zero-padding.
+        """
         pad = 2 * self.n_pix
         if self.use_next_fast_len:
             pad = next_fast_len(pad)
-        return torch.fft.fft2(x, (pad, pad))
+        return torch.fft.rfft2(x, (pad, pad))
 
-    def _unpad_fft(self, x):
+    def _unpad_fft(self, x: Tensor) -> Tensor:
+        """
+        Remove padding from the result of a 2D FFT.
+
+        Args:
+            x (Tensor): The input tensor with padding.
+
+        Returns:
+            Tensor: The input tensor without padding.
+        """
         return x[..., -self.n_pix :, -self.n_pix :]
 
-    def _unpad_conv2d(self, x):
+    def _unpad_conv2d(self, x: Tensor) -> Tensor:
+        """
+        Remove padding from the result of a 2D convolution.
+
+        Args:
+            x (Tensor): The input tensor with padding.
+
+        Returns:
+            Tensor: The input tensor without padding.
+        """
         return x[..., 1:, 1:]
 
     @property
     def mode(self):
+        """
+        Get the convolution mode of the KappaGrid object.
+
+        Returns:
+            str: The convolution mode, either "fft" or "conv2d".
+        """
         return self._mode
 
     @mode.setter
-    def mode(self, mode):
+    def mode(self, mode: str):
+        """
+        Set the convolution mode of the KappaGrid object.
+
+        Args:
+            mode (str): The convolution mode to be set, either "fft" or "conv2d".
+        """
         if mode == "fft":
             # Create FFTs of kernels
             self.Psi_kernel_tilde = self._fft2_padded(self.Psi_kernel)
@@ -125,6 +191,18 @@ class KappaGrid(ThinLens):
     def alpha(
         self, thx: Tensor, thy: Tensor, z_s: Tensor, x: Optional[dict[str, Any]] = None
     ) -> tuple[Tensor, Tensor]:
+        """
+        Compute the deflection angles at the specified positions using the given kappa map.
+
+        Args:
+            thx (Tensor): The x-coordinates of the positions to compute the deflection angles for.
+            thy (Tensor): The y-coordinates of the positions to compute the deflection angles for.
+            z_s (Tensor): The source redshift.
+            x (Optional[dict[str, Any]]): A dictionary containing additional parameters.
+
+        Returns:
+            tuple[Tensor, Tensor]: The x and y components of the deflection angles at the specified positions.
+        """
         z_l, thx0, thy0, kappa_map = self.unpack(x)
 
         if self.mode == "fft":
@@ -142,17 +220,35 @@ class KappaGrid(ThinLens):
         ).reshape(thx.shape)
         return alpha_x, alpha_y
 
-    def _alpha_fft(self, kappa_map):
+    def _alpha_fft(self, kappa_map: Tensor) -> tuple[Tensor, Tensor]:
+        """
+        Compute the deflection angles using the Fast Fourier Transform (FFT) method.
+
+        Args:
+            kappa_map (Tensor): The 2D tensor representing the kappa map.
+
+        Returns:
+            tuple[Tensor, Tensor]: The x and y components of the deflection angles.
+        """
         kappa_tilde = self._fft2_padded(kappa_map)
-        alpha_x = torch.fft.ifft2(kappa_tilde * self.ax_kernel_tilde).real * (
+        alpha_x = torch.fft.irfft2(kappa_tilde * self.ax_kernel_tilde) * (
             self.res**2 / pi
         )
-        alpha_y = torch.fft.ifft2(kappa_tilde * self.ay_kernel_tilde).real * (
+        alpha_y = torch.fft.irfft2(kappa_tilde * self.ay_kernel_tilde) * (
             self.res**2 / pi
         )
         return self._unpad_fft(alpha_x), self._unpad_fft(alpha_y)
 
-    def _alpha_conv2d(self, kappa_map):
+    def _alpha_conv2d(self, kappa_map: Tensor) -> tuple[Tensor, Tensor]::
+        """
+        Compute the deflection angles using the 2D convolution method.
+
+        Args:
+            kappa_map (Tensor): The 2D tensor representing the kappa map.
+
+        Returns:
+            tuple[Tensor, Tensor]: The x and y components of the deflection angles.
+        """
         # Use kappa_map as kernel since the kernel is twice as large. Flip since
         # we actually want the cross-correlation.
         kappa_map_flipped = kappa_map.flip((-1, -2))[None, None]
@@ -167,6 +263,18 @@ class KappaGrid(ThinLens):
     def Psi(
         self, thx: Tensor, thy: Tensor, z_s: Tensor, x: Optional[dict[str, Any]] = None
     ) -> Tensor:
+        """
+        Compute the lensing potential at the specified positions using the given kappa map.
+
+        Args:
+        thx (Tensor): The x-coordinates of the positions to compute the lensing potential for.
+        thy (Tensor): The y-coordinates of the positions to compute the lensing potential for.
+        z_s (Tensor): The source redshift.
+        x (Optional[dict[str, Any]]): A dictionary containing additional parameters.
+
+        Returns:
+            Tensor: The lensing potential at the specified positions.
+        """
         z_l, thx0, thy0, kappa_map = self.unpack(x)
 
         if self.mode == "fft":
@@ -180,14 +288,32 @@ class KappaGrid(ThinLens):
             Psi_map, (thx - thx0).view(-1) / scale, (thy - thy0).view(-1) / scale
         ).reshape(thx.shape)
 
-    def _Psi_fft(self, kappa_map):
+    def _Psi_fft(self, kappa_map: Tensor) -> Tensor:
+        """
+        Compute the lensing potential using the Fast Fourier Transform (FFT) method.
+    
+        Args:
+            kappa_map (Tensor): The 2D tensor representing the kappa map.
+    
+        Returns:
+            Tensor: The lensing potential.
+        """
         kappa_tilde = self._fft2_padded(kappa_map)
-        Psi = torch.fft.ifft2(kappa_tilde * self.Psi_kernel_tilde).real * (
+        Psi = torch.fft.irfft2(kappa_tilde * self.Psi_kernel_tilde) * (
             self.res**2 / pi
         )
         return self._unpad_fft(Psi)
 
-    def _Psi_conv2d(self, kappa_map):
+    def _Psi_conv2d(self, kappa_map: Tensor) -> Tensor:
+        """
+        Compute the lensing potential using the 2D convolution method.
+    
+        Args:
+            kappa_map (Tensor): The 2D tensor representing the kappa map.
+    
+        Returns:
+            Tensor: The lensing potential.
+        """
         # Use kappa_map as kernel since the kernel is twice as large. Flip since
         # we actually want the cross-correlation.
         kappa_map_flipped = kappa_map.flip((-1, -2))[None, None]
@@ -199,4 +325,19 @@ class KappaGrid(ThinLens):
     def kappa(
         self, thx: Tensor, thy: Tensor, z_s: Tensor, x: Optional[dict[str, Any]] = None
     ) -> Tensor:
+        """
+        Compute the convergence (kappa) at the specified positions. This method is not implemented.
+    
+        Args:
+            thx (Tensor): The x-coordinates of the positions to compute the convergence for.
+            thy (Tensor): The y-coordinates of the positions to compute the convergence for.
+            z_s (Tensor): The source redshift.
+            x (Optional[dict[str, Any]]): A dictionary containing additional parameters.
+    
+        Returns:
+            Tensor: The convergence at the specified positions.
+    
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
         raise NotImplementedError()

--- a/src/caustic/lenses/kappa_grid.py
+++ b/src/caustic/lenses/kappa_grid.py
@@ -240,7 +240,7 @@ class KappaGrid(ThinLens):
         )
         return self._unpad_fft(alpha_x), self._unpad_fft(alpha_y)
 
-    def _alpha_conv2d(self, kappa_map: Tensor) -> tuple[Tensor, Tensor]::
+    def _alpha_conv2d(self, kappa_map: Tensor) -> tuple[Tensor, Tensor]:
         """
         Compute the deflection angles using the 2D convolution method.
 

--- a/src/caustic/lenses/kappa_grid.py
+++ b/src/caustic/lenses/kappa_grid.py
@@ -12,7 +12,6 @@ from .base import ThinLens
 
 __all__ = ("KappaGrid",)
 
-
 class KappaGrid(ThinLens):
     def __init__(
         self,
@@ -110,11 +109,11 @@ class KappaGrid(ThinLens):
         self.ax_kernel = self.ax_kernel.to(device=device, dtype=dtype)
         self.ay_kernel = self.ay_kernel.to(device=device, dtype=dtype)
         if self.Psi_kernel_tilde is not None:
-            self.Psi_kernel_tilde = self.Psi_kernel_tilde.to(device=device, dtype=dtype)
+            self.Psi_kernel_tilde = self.Psi_kernel_tilde.to(device=device)
         if self.ax_kernel_tilde is not None:
-            self.ax_kernel_tilde = self.ax_kernel_tilde.to(device=device, dtype=dtype)
+            self.ax_kernel_tilde = self.ax_kernel_tilde.to(device=device)
         if self.ay_kernel_tilde is not None:
-            self.ay_kernel_tilde = self.ay_kernel_tilde.to(device=device, dtype=dtype)
+            self.ay_kernel_tilde = self.ay_kernel_tilde.to(device=device)
 
     def _fft2_padded(self, x: Tensor) -> Tensor:
         """

--- a/src/caustic/lenses/kappa_grid.py
+++ b/src/caustic/lenses/kappa_grid.py
@@ -49,7 +49,8 @@ class KappaGrid(ThinLens):
             mode (str, optional): The convolution mode for calculating deflection angles and lensing potential.
                 It can be either "fft" (Fast Fourier Transform) or "conv2d" (2D convolution). Default is "fft".
             use_next_fast_len (bool, optional): If True, adds additional padding to speed up the FFT by calling
-                `scipy.fft.next_fast_len`. The speed boost can be substantial when `n_pix` is prime. Default is True.
+                `scipy.fft.next_fast_len`. The speed boost can be substantial when `n_pix` is a multiple of a
+                small prime number. Default is True.
 
         """
         

--- a/src/caustic/utils.py
+++ b/src/caustic/utils.py
@@ -205,7 +205,7 @@ def interp2d(
         raise ValueError(f"{method} is not a valid interpolation method")
 
     if padding_mode == "zeros":  # else padding_mode == "extrapolate"
-        result[idxs_out_of_bounds] = 0.0
+        result[idxs_out_of_bounds] = torch.zeros_like(result[idxs_out_of_bounds])
 
     return result
 

--- a/src/caustic/utils.py
+++ b/src/caustic/utils.py
@@ -87,6 +87,64 @@ def safe_log(x):
     return out
 
 
+
+def _h_poly(t):
+    """Helper function to compute the 'h' polynomial matrix used in the
+    cubic spline.
+    
+    Args:
+        t (Tensor): A 1D tensor representing the normalized x values.
+    
+    Returns:
+        Tensor: A 2D tensor of size (4, len(t)) representing the 'h' polynomial matrix.
+
+    """
+
+    tt = t[None, :] ** (torch.arange(4, device=t.device)[:, None])
+    A = torch.tensor(
+        [[1, 0, -3, 2], [0, 1, -2, 1], [0, 0, 3, -2], [0, 0, -1, 1]],
+        dtype=t.dtype,
+        device=t.device,
+    )
+    return A @ tt
+
+def interp1d(x: Tensor, y: Tensor, xs: Tensor, extend: str = "extrapolate") -> Tensor:
+    """Compute the 1D cubic spline interpolation for the given data points
+    using PyTorch.
+
+    Args:
+        x (Tensor): A 1D tensor representing the x-coordinates of the known data points.
+        y (Tensor): A 1D tensor representing the y-coordinates of the known data points.
+        xs (Tensor): A 1D tensor representing the x-coordinates of the positions where
+                     the cubic spline function should be evaluated.
+        extend (str, optional): The method for handling extrapolation, either "const", "extrapolate", or "linear".
+                                Default is "extrapolate".
+                                "const": Use the value of the last known data point for extrapolation.
+                                "linear": Use linear extrapolation based on the last two known data points.
+                                "extrapolate": Use cubic extrapolation of data.
+    
+    Returns:
+        Tensor: A 1D tensor representing the interpolated values at the specified positions (xs).
+
+    """
+    m = (y[1:] - y[:-1]) / (x[1:] - x[:-1])
+    m = torch.cat([m[[0]], (m[1:] + m[:-1]) / 2, m[[-1]]])
+    idxs = torch.searchsorted(x[:-1], xs) - 1
+    dx = x[idxs + 1] - x[idxs]
+    hh = _h_poly((xs - x[idxs]) / dx)
+    ret = (
+        hh[0] * y[idxs]
+        + hh[1] * m[idxs] * dx
+        + hh[2] * y[idxs + 1]
+        + hh[3] * m[idxs + 1] * dx
+    )
+    if extend == "const":
+        ret[xs > x[-1]] = y[-1]
+    elif extend == "linear":
+        indices = xs > x[-1]
+        ret[indices] = y[-1] + (xs[indices] - x[-1]) * (y[-1] - y[-2]) / (x[-1] - x[-2])
+    return ret
+
 def interp2d(
     im: Tensor,
     x: Tensor,


### PR DESCRIPTION
Kappa Grid is updated with the following:
- dtype no longer enforced for frequency space kernels
- docstrings added
- fft changed to rfft since kernels are real valued
- enforced shapes for fft and ifft

This PR closes #35 