### PR TITLE
Batch, dtypes and to method

### DIFF
--- a/caustic/lenses/pixelated_convergence.py
+++ b/caustic/lenses/pixelated_convergence.py
@@ -22,7 +22,7 @@ class PixelatedConvergence(ThinLens):
         x0: Optional[Tensor] = torch.tensor(0.0),
         y0: Optional[Tensor] = torch.tensor(0.0),
         convergence_map: Optional[Tensor] = None,
-        convergence_map_shape: Optional[tuple[int, ...]] = None,
+        shape: Optional[tuple[int, ...]] = None,
         convolution_mode: str = "fft",
         use_next_fast_len: bool = True,
         name: str = None,
@@ -45,7 +45,7 @@ class PixelatedConvergence(ThinLens):
             x0 (Optional[Tensor]): The x-coordinate of the center of the grid.
             y0 (Optional[Tensor]): The y-coordinate of the center of the grid.
             convergence_map (Optional[Tensor]): A 2D tensor representing the convergence map.
-            convergence_map_shape (Optional[tuple[int, ...]]): The shape of the convergence map.
+            shape (Optional[tuple[int, ...]]): The shape of the convergence map.
             convolution_mode (str, optional): The convolution mode for calculating deflection angles and lensing potential.
                 It can be either "fft" (Fast Fourier Transform) or "conv2d" (2D convolution). Default is "fft".
             use_next_fast_len (bool, optional): If True, adds additional padding to speed up the FFT by calling
@@ -58,16 +58,16 @@ class PixelatedConvergence(ThinLens):
 
         if convergence_map is not None and convergence_map.ndim != 2:
             raise ValueError(
-                f"convergence_map must be 2D (received {convergence_map.ndim}D tensor)"
+                f"convergence_map must be 2D. Received a {convergence_map.ndim}D tensor)"
             )
-        elif convergence_map_shape is not None and len(convergence_map_shape) != 2:
+        elif shape is not None and len(shape) != 2:
             raise ValueError(
-                f"convergence_map_shape must be 2D (received {len(convergence_map_shape)}D)"
+                f"shape must specify a 2D tensor. Received shape={shape}"
             )
 
         self.add_param("x0", x0)
         self.add_param("y0", y0)
-        self.add_param("convergence_map", convergence_map, convergence_map_shape)
+        self.add_param("convergence_map", convergence_map, shape)
 
         self.n_pix = n_pix
         self.fov = fov

--- a/caustic/lenses/pseudo_jaffe.py
+++ b/caustic/lenses/pseudo_jaffe.py
@@ -96,7 +96,7 @@ class PseudoJaffe(ThinLens):
         )
 
     @staticmethod
-    def convergence_0(
+    def central_convergence(
         z_l,
         z_s,
         rho_0,

--- a/caustic/parameter.py
+++ b/caustic/parameter.py
@@ -1,7 +1,9 @@
 from typing import Optional, Union
+from collections import OrderedDict
 
 import torch
 from torch import Tensor
+from caustic.namespace_dict import NamespaceDict
 
 __all__ = ("Parameter",)
 
@@ -31,6 +33,8 @@ class Parameter:
             ValueError: If both value and shape are None, or if shape is provided and doesn't match the shape of the value.
         """
         # Must assign one of value or shape
+        self._parents = NamespaceDict()
+        self._childs = None # A Parameter will always be a leaf node of the DAG
         self._value = value
         if value is None:
             if shape is None:

--- a/caustic/parameter.py
+++ b/caustic/parameter.py
@@ -22,8 +22,6 @@ class Parameter:
         self, value: Optional[Union[Tensor, float]] = None, shape: Optional[tuple[int, ...]] = ()
     ):
         # Must assign one of value or shape
-        self._parents = NamespaceDict()
-        self._childs = None # A Parameter will always be a leaf node of the DAG
         if value is None:
             if shape is None:
                 raise ValueError("If value is None, a shape must be provided")
@@ -72,9 +70,7 @@ class Parameter:
     def set_static(self):
         self.value = None
 
-    def to(
-        self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
-    ):
+    def to(self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None):
         """
         Moves and/or casts the values of the parameter.
 
@@ -84,6 +80,7 @@ class Parameter:
         """
         if self.static:
             self.value = self._value.to(device=device, dtype=dtype)
+        return self
 
     def __repr__(self) -> str:
         if self.static:

--- a/caustic/parameter.py
+++ b/caustic/parameter.py
@@ -1,5 +1,4 @@
 from typing import Optional, Union
-from collections import OrderedDict
 
 import torch
 from torch import Tensor
@@ -22,72 +21,56 @@ class Parameter:
     def __init__(
         self, value: Optional[Union[Tensor, float]] = None, shape: Optional[tuple[int, ...]] = ()
     ):
-        """
-        Initializes an instance of the Parameter class.
-
-        Args:
-            value (Optional[Union[Tensor, float]]: The value of the parameter. Defaults to None.
-            shape (Optional[tuple[int, ...]]): The shape of the parameter. Defaults to an empty tuple.
-
-        Raises:
-            ValueError: If both value and shape are None, or if shape is provided and doesn't match the shape of the value.
-        """
         # Must assign one of value or shape
         self._parents = NamespaceDict()
         self._childs = None # A Parameter will always be a leaf node of the DAG
-        self._value = value
         if value is None:
             if shape is None:
                 raise ValueError("If value is None, a shape must be provided")
+            if not isinstance(shape, tuple):
+                raise TypeError("The shape of a parameter must be a tuple")
             self._shape = shape
         else:
-            value = torch.as_tensor(value)
+            value = torch.as_tensor(value).float() # set float32 as default dtype here
             if shape != value.shape:
                 raise ValueError(
                     f"value's shape {value.shape} does not match provided shape {shape}"
                 )
-            self._value = value
             self._shape = value.shape
+        self._value = value
+        self._dtype = None if value is None else value.dtype
 
     @property
     def static(self) -> bool:
-        """
-        Checks if the parameter is static.
-
-        Returns:
-            bool: True if the parameter is static, False otherwise.
-        """
         return not self.dynamic
 
     @property
     def dynamic(self) -> bool:
-        """
-        Checks if the parameter is dynamic.
-
-        Returns:
-            bool: True if the parameter is dynamic, False otherwise.
-        """
         return self._value is None
 
     @property
     def value(self) -> Optional[Tensor]:
-        """
-        Returns the value of the parameter.
-
-        Returns:
-            Optional[Tensor]: The value of the parameter, or None if the parameter is dynamic.
-        """
         return self._value
+    
+    @value.setter
+    def value(self, value: Union[None, Tensor, float]):
+        if value is not None:
+            value = torch.as_tensor(value)
+            if value.shape != self.shape:
+                raise ValueError(f"Cannot set Parameter value with a different shape. Received {value.shape}, expected {self.shape}")
+        self._value = value
+        self._dtype = None if value is None else value.dtype
+    
+    @property
+    def dtype(self):
+        return self._dtype
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """
-        Returns the shape of the parameter.
-
-        Returns:
-            tuple[int, ...]: The shape of the parameter.
-        """
         return self._shape
+    
+    def set_static(self):
+        self.value = None
 
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
@@ -99,17 +82,11 @@ class Parameter:
             device (Optional[torch.device], optional): The device to move the values to. Defaults to None.
             dtype (Optional[torch.dtype], optional): The desired data type. Defaults to None.
         """
-        if self._value is not None:
-            self._value = self._value.to(device=device, dtype=dtype)
+        if self.static:
+            self.value = self._value.to(device=device, dtype=dtype)
 
     def __repr__(self) -> str:
-        """
-        Returns a string representation of the Parameter object.
-
-        Returns:
-            str: A string representation of the Parameter object.
-        """
         if self.static:
-            return f"Param(value={self.value})"
+            return f"Param(value={self.value}, dtype={str(self.dtype)[-1]})"
         else:
             return f"Param(shape={self.shape})"

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -101,11 +101,8 @@ class Parametrized:
         """
         Moves static Params for this component and its childs to the specified device and casts them to the specified data type.
         """
-        # TODO I think we should make users specify a separate method so we dont override this behavior
-        for name in self._params.keys():
-            param = self._params[name]
-            if isinstance(param, torch.Tensor):
-                self._params[name] = param.to(device, dtype)
+        for name, p in self._params.items():
+            self._params[name] = p.to(device, dtype)
         for child in self._childs.values():
             child.to(device, dtype)
         return self

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -114,7 +114,7 @@ class Parametrized:
         """
         self._params[name] = Parameter(value, shape)
         if value is None:
-            assert isinstance(shape, tuple)  # quiet pyright error
+            assert isinstance(shape, (list, tuple))  # quiet pyright error
             size = prod(shape)
             self._dynamic_size += size
             self._n_dynamic += 1

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict, defaultdict
 from math import prod
-from typing import Optional, Union, Callable
+from typing import Optional, Union
 
 import torch
 import re
@@ -134,7 +134,7 @@ class Parametrized:
     def add_param(
         self,
         name: str,
-        value: Optional[Union[Tensor, float, Parameter, Callable]] = None,
+        value: Optional[Union[Tensor, float]] = None,
         shape: Optional[tuple[int, ...]] = (),
     ):
         """

--- a/caustic/simulator.py
+++ b/caustic/simulator.py
@@ -17,4 +17,11 @@ class Simulator(Parametrized):
     """
 
     def __call__(self, *args, **kwargs):
-        return self.forward(self.pack(args[0]), *args[1:], **kwargs)
+        packed_args = self.pack(args[0])
+        return self.forward(packed_args, *args[1:], **kwargs)
+        # packed_args, batched = self.pack(args[0])
+        # out = self.forward(packed_args, *args[1:], **kwargs)
+        # if batched:
+            # return out
+        # else:
+            # return out[0] # removes the singleton batch dimension used internally

--- a/caustic/sources/pixelated.py
+++ b/caustic/sources/pixelated.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from torch import Tensor
 
@@ -26,10 +26,10 @@ class Pixelated(Source):
     """
     def __init__(
         self,
-        x0: Optional[Tensor] = None,
-        y0: Optional[Tensor] = None,
         image: Optional[Tensor] = None, 
-        pixelscale: Optional[Tensor] = None,
+        x0: Optional[Union[Tensor, float]] = None,
+        y0: Optional[Union[Tensor, float]] = None,
+        pixelscale: Optional[Union[Tensor, float]] = None,
         image_shape: Optional[tuple[int, ...]] = None,
         name: str = None,
     ):
@@ -44,7 +44,7 @@ class Pixelated(Source):
             pixelscale (Optional[Tensor]): The pixelscale of the source image in the lens plane in units of arcsec/pixel.
             image_shape (Optional[tuple[int, ...]]): The shape of the source image.
         """
-        super().__init__(name)
+        super().__init__(name=name)
         self.add_param("x0", x0)
         self.add_param("y0", y0)
         self.add_param("image", image, image_shape)

--- a/caustic/sources/pixelated.py
+++ b/caustic/sources/pixelated.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 
 from torch import Tensor
+from torch import vmap
 
 from ..utils import interp2d
 from .base import Source
@@ -10,8 +11,8 @@ __all__ = ("Pixelated",)
 
 class Pixelated(Source):
     """
-    `Pixelated` is a subclass of the abstract class `Source`. It represents a source in a strong 
-    gravitational lensing system where the source is an image.
+    `Pixelated` is a subclass of the abstract class `Source`. It representes the brightness profile of 
+    source with a pixelated grid of intensity values.
     
     This class provides a concrete implementation of the `brightness` method required by the `Source` 
     superclass. In this implementation, brightness is determined by interpolating values from the 
@@ -22,7 +23,7 @@ class Pixelated(Source):
         y0 (Optional[Tensor]): The y-coordinate of the source image's center.
         image (Optional[Tensor]): The source image from which brightness values will be interpolated.
         pixelscale (Optional[Tensor]): The pixelscale of the source image in the lens plane in units of arcsec/pixel.
-        image_shape (Optional[tuple[int, ...]]): The shape of the source image.
+        shape (Optional[tuple[int, ...]]): The shape of the source image.
     """
     def __init__(
         self,
@@ -30,7 +31,7 @@ class Pixelated(Source):
         x0: Optional[Union[Tensor, float]] = None,
         y0: Optional[Union[Tensor, float]] = None,
         pixelscale: Optional[Union[Tensor, float]] = None,
-        image_shape: Optional[tuple[int, ...]] = None,
+        shape: Optional[tuple[int, ...]] = None,
         name: str = None,
     ):
         """
@@ -42,14 +43,22 @@ class Pixelated(Source):
             y0 (Optional[Tensor]): The y-coordinate of the source image's center.
             image (Optional[Tensor]): The source image from which brightness values will be interpolated.
             pixelscale (Optional[Tensor]): The pixelscale of the source image in the lens plane in units of arcsec/pixel.
-            image_shape (Optional[tuple[int, ...]]): The shape of the source image.
+            shape (Optional[tuple[int, ...]]): The shape of the source image.
         """
+        if image is not None and image.ndim not in [2, 3]:
+            raise ValueError(
+                f"image must be 2D or 3D (channels first). Received a {image.ndim}D tensor)"
+            )
+        elif shape is None and len(shape) not in [2, 3]:
+            raise ValueError(
+                f"shape must be specify 2D or 3D tensors. Received shape={shape}"
+            )
         super().__init__(name=name)
         self.add_param("x0", x0)
         self.add_param("y0", y0)
-        self.add_param("image", image, image_shape)
+        self.add_param("image", image, shape)
         self.add_param("pixelscale", pixelscale)
-
+    
     def brightness(self, x, y, params: Optional["Packed"]):
         """
         Implements the `brightness` method for `Pixelated`. The brightness at a given point is 
@@ -60,7 +69,7 @@ class Pixelated(Source):
                 This could be a single value or a tensor of values.
             y (Tensor): The y-coordinate(s) at which to calculate the source brightness. 
                 This could be a single value or a tensor of values.
-            P (Optional[Packed]): A dictionary containing additional parameters that might be required to 
+            params (Optional[Packed]): A dictionary containing additional parameters that might be required to 
                 calculate the brightness. 
 
         Returns:
@@ -68,6 +77,4 @@ class Pixelated(Source):
             determined by interpolating values from the source image.
         """
         x0, y0, image, pixelscale = self.unpack(params)
-        return interp2d(
-            image, (x - x0).view(-1) / pixelscale, (y - y0).view(-1) / pixelscale
-        ).reshape(x.shape)
+        return interp2d(image, (x - x0).view(-1) / pixelscale, (y - y0).view(-1) / pixelscale).reshape(x.shape)

--- a/caustic/sources/sersic.py
+++ b/caustic/sources/sersic.py
@@ -55,7 +55,7 @@ class Sersic(Source):
             s (float): A small constant for numerical stability.
             use_lenstronomy_k (bool): A flag indicating whether to use lenstronomy to compute the value of k.
         """
-        super().__init__(name)
+        super().__init__(name=name)
         self.add_param("x0", x0)
         self.add_param("y0", y0)
         self.add_param("q", q)

--- a/caustic/utils.py
+++ b/caustic/utils.py
@@ -276,7 +276,7 @@ def interp2d(
         raise ValueError(f"{method} is not a valid interpolation method")
 
     if padding_mode == "zeros":  # else padding_mode == "extrapolate"
-        result[idxs_out_of_bounds] = torch.zeros_like(result[idxs_out_of_bounds])
+        result = torch.where(idxs_out_of_bounds, torch.zeros_like(result), result)
 
     return result
 

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -38,13 +38,13 @@ def test_vmapped_simulator_with_pixelated_modules():
     print(x[2].shape)
     assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
     
-    # test tensor input
-    x_tensor = torch.stack(x, dim=1)
-    print(x_tensor.shape)
-    assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
+    # test tensor input: Does not work well with images since it would require unflattening the images in caustic
+    # x_tensor = torch.concat([_x.view(2, -1) for _x in x], dim=1)
+    # print(x_tensor.shape)
+    # assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
     
     # Test dictionary input: Only module with dynamic parameters are required
-    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params, "kappa": kappa}
+    x_dict = {"cosmo": cosmo_params, "source": source, "lens": lens_params, "kappa": kappa}
     print(x_dict)
     assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
     

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -4,12 +4,12 @@ from utils import setup_image_simulator, setup_simulator
 import pytest
 
 def test_vmapped_simulator():
-    sim, (cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
+    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
     n_pix = sim.n_pix
     print(sim.params)
  
     # test list input
-    x = cosmo_params + lens_params + source_params
+    x = sim_params + cosmo_params + lens_params + source_params
     print(x[0].shape)
     assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
     
@@ -19,12 +19,12 @@ def test_vmapped_simulator():
     assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
     
     # Test dictionary input: Only module with dynamic parameters are required
-    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params}
+    x_dict = {"simulator": sim_params, "cosmo": cosmo_params, "source": source_params, "lens": lens_params}
     print(x_dict)
     assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
     
     # Test semantic list (one tensor per module)
-    x_semantic = [cosmo_params, lens_params, source_params]
+    x_semantic = [sim_params, cosmo_params, lens_params, source_params]
     assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
 
 

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -28,32 +28,32 @@ def test_vmapped_simulator():
     assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
 
 
-# def test_vmapped_simulator_with_pixelated_modules():
-    # sim, (cosmo_params, lens_params, kappa, source) = setup_image_simulator(batched_params=True)
-    # n_pix = sim.n_pix
-    # print(sim.params)
+def test_vmapped_simulator_with_pixelated_modules():
+    sim, (cosmo_params, lens_params, kappa, source) = setup_image_simulator(batched_params=True)
+    n_pix = sim.n_pix
+    print(sim.params)
  
-    # # test list input
-    # x = cosmo_params + lens_params + kappa + source 
-    # print(x[2].shape)
-    # assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
+    # test list input
+    x = cosmo_params + lens_params + kappa + source 
+    print(x[2].shape)
+    assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
     
-    # # test tensor input
-    # x_tensor = torch.stack(x, dim=1)
-    # print(x_tensor.shape)
-    # assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
+    # test tensor input
+    x_tensor = torch.stack(x, dim=1)
+    print(x_tensor.shape)
+    assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
     
-    # # Test dictionary input: Only module with dynamic parameters are required
-    # x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params, "kappa": kappa}
-    # print(x_dict)
-    # assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
+    # Test dictionary input: Only module with dynamic parameters are required
+    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params, "kappa": kappa}
+    print(x_dict)
+    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
     
-    # # Test passing tensor in source and kappa instead of list
-    # x_dict = {"cosmo": cosmo_params, "source": source[0], "lens": lens_params, "kappa": kappa[0]}
-    # print(x_dict)
-    # assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
+    # Test passing tensor in source and kappa instead of list
+    x_dict = {"cosmo": cosmo_params, "source": source[0], "lens": lens_params, "kappa": kappa[0]}
+    print(x_dict)
+    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
     
-    # # Test semantic list (one tensor per module)
-    # x_semantic = [cosmo_params, lens_params, kappa, source]
-    # assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
+    # Test semantic list (one tensor per module)
+    x_semantic = [cosmo_params, lens_params, kappa, source]
+    assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
 

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -1,0 +1,59 @@
+import torch
+from torch import vmap
+from utils import setup_image_simulator, setup_simulator
+import pytest
+
+def test_vmapped_simulator():
+    sim, (cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
+    n_pix = sim.n_pix
+    print(sim.params)
+ 
+    # test list input
+    x = cosmo_params + lens_params + source_params
+    print(x[0].shape)
+    assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
+    
+    # test tensor input
+    x_tensor = torch.stack(x, dim=1)
+    print(x_tensor.shape)
+    assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
+    
+    # Test dictionary input: Only module with dynamic parameters are required
+    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params}
+    print(x_dict)
+    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
+    
+    # Test semantic list (one tensor per module)
+    x_semantic = [cosmo_params, lens_params, source_params]
+    assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
+
+
+# def test_vmapped_simulator_with_pixelated_modules():
+    # sim, (cosmo_params, lens_params, kappa, source) = setup_image_simulator(batched_params=True)
+    # n_pix = sim.n_pix
+    # print(sim.params)
+ 
+    # # test list input
+    # x = cosmo_params + lens_params + kappa + source 
+    # print(x[2].shape)
+    # assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
+    
+    # # test tensor input
+    # x_tensor = torch.stack(x, dim=1)
+    # print(x_tensor.shape)
+    # assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
+    
+    # # Test dictionary input: Only module with dynamic parameters are required
+    # x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params, "kappa": kappa}
+    # print(x_dict)
+    # assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
+    
+    # # Test passing tensor in source and kappa instead of list
+    # x_dict = {"cosmo": cosmo_params, "source": source[0], "lens": lens_params, "kappa": kappa[0]}
+    # print(x_dict)
+    # assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
+    
+    # # Test semantic list (one tensor per module)
+    # x_semantic = [cosmo_params, lens_params, kappa, source]
+    # assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
+

--- a/test/test_kappa_grid.py
+++ b/test/test_kappa_grid.py
@@ -24,7 +24,7 @@ def _setup(n_pix, mode, use_next_fast_len):
     th_s = torch.tensor(0.2)
     rho_0 = torch.tensor(1.0)
 
-    kappa_0 = lens_pj.convergence_0(z_l, z_s, rho_0, th_core, th_s, cosmology)
+    kappa_0 = lens_pj.central_convergence(z_l, z_s, rho_0, th_core, th_s, cosmology)
     # z_l, thx0, thy0, kappa_0, th_core, th_s
     x_pj = torch.tensor([z_l, thx0, thy0, kappa_0, th_core, th_s])
 
@@ -39,7 +39,7 @@ def _setup(n_pix, mode, use_next_fast_len):
         n_pix,
         cosmology,
         z_l=z_l,
-        convergence_map_shape=(n_pix, n_pix),
+        shape=(n_pix, n_pix),
         convolution_mode=mode,
         use_next_fast_len=use_next_fast_len,
         name="kg",

--- a/test/test_parameter.py
+++ b/test/test_parameter.py
@@ -1,6 +1,6 @@
-# import torch
-# from caustic import EPL, Simulator, Sersic, FlatLambdaCDM
-
+import torch
+from caustic import EPL, Simulator, Sersic, FlatLambdaCDM, Pixelated, PixelatedConvergence
+import pytest
 
 # For future PR currently this test fails
 # def test_static_parameter_init():
@@ -8,3 +8,23 @@
     # print(module.params)
     # module.to(dtype=torch.float16)
     # assert module.params.static.FlatLambdaCDM.h0.value.dtype == torch.float16
+
+def test_shape_error_messages():
+    # with pytest.raises(TypeError):
+        # # User cannot enter a list, only a tuple for type checking and consistency with torch
+        # module = Pixelated(shape=[8, 8])
+    
+    # with pytest.raises(ValueError):
+        # module = Pixelated(shape=(8,))
+    
+    fov = 7.8
+    n_pix = 20
+    cosmo = FlatLambdaCDM()
+    with pytest.raises(TypeError):
+        # User cannot enter a list, only a tuple (because of type checking and consistency with torch)
+        PixelatedConvergence(fov, n_pix, cosmo, shape=[8, 8])
+    
+    with pytest.raises(ValueError): 
+        # wrong number of dimensions
+        PixelatedConvergence(fov, n_pix, cosmo, shape=(8,))
+

--- a/test/test_parametrized.py
+++ b/test/test_parametrized.py
@@ -156,6 +156,12 @@ def test_to_method():
 
     module = Sersic(x0=np.array(0.5))
     assert module.x0.dtype == torch.float32
+    
+    # Check that all parameters are converted to correct type
+    sim.to(dtype=torch.float16)
+    assert sim.z_s.dtype is None # dynamic parameter
+    assert sim.lens.cosmo.Om0.dtype == torch.float16
+    assert sim.cosmo.Om0.dtype == torch.float16
   
 
 def test_parameter_redefinition():

--- a/test/test_parametrized.py
+++ b/test/test_parametrized.py
@@ -1,6 +1,8 @@
 import torch
 from torch import vmap
+import numpy as np
 from caustic import Simulator, EPL, Sersic, FlatLambdaCDM
+from caustic.parameter import Parameter
 from utils import setup_image_simulator, setup_simulator
 import pytest
 
@@ -32,11 +34,11 @@ def test_graph():
 
 
 def test_unpack_all_modules_dynamic():
-    sim, (cosmo_params, lens_params, source_params) = setup_simulator()
+    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator()
     n_pix = sim.n_pix
     
     # test list input
-    x = cosmo_params + lens_params + source_params
+    x = sim_params + cosmo_params + lens_params + source_params
     assert sim(x).shape == torch.Size([n_pix, n_pix])
     
     # test tensor input
@@ -44,18 +46,18 @@ def test_unpack_all_modules_dynamic():
     assert sim(x_tensor).shape == torch.Size([n_pix, n_pix])
     
     # Test dictionary input: Only module with dynamic parameters are required
-    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params}
+    x_dict = {"simulator": sim_params, "cosmo": cosmo_params, "source": source_params, "lens": lens_params}
     print(x_dict)
     assert sim(x_dict).shape == torch.Size([n_pix, n_pix])
     
     # Test semantic list (one tensor per module)
-    x_semantic = [torch.stack(module) for module in [cosmo_params, lens_params, source_params]]
+    x_semantic = [torch.stack(module) for module in [sim_params, cosmo_params, lens_params, source_params]]
     assert sim(x_semantic).shape == torch.Size([n_pix, n_pix])
 
 
 def test_unpack_some_modules_static():
     # same test as above but cosmo is completely static so not fed in the forward method
-    sim, (_, lens_params, source_params) = setup_simulator(cosmo_static=True)
+    sim, (_, _, lens_params, source_params) = setup_simulator(cosmo_static=True, simulator_static=True)
     n_pix = sim.n_pix
 
     # test list input
@@ -137,80 +139,42 @@ def test_parametrized_name_collision():
     assert "Sim" in lens._parents.keys()
 
 
-def test_vmapped_simulator():
-    sim, (cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
-    n_pix = sim.n_pix
-    print(sim.params)
- 
-    # test list input
-    x = cosmo_params + lens_params + source_params
-    print(x[0].shape)
-    assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
-    
-    # test tensor input
-    x_tensor = torch.stack(x, dim=1)
-    print(x_tensor.shape)
-    assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
-    
-    # Test dictionary input: Only module with dynamic parameters are required
-    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params}
-    print(x_dict)
-    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
-    
-    # Test semantic list (one tensor per module)
-    x_semantic = [cosmo_params, lens_params, source_params]
-    assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
-
-def test_vmapped_simulator_with_pixelated_modules():
-    sim, (cosmo_params, lens_params, kappa, source) = setup_image_simulator(batched_params=True)
-    n_pix = sim.n_pix
-    print(sim.params)
- 
-    # test list input
-    x = cosmo_params + lens_params + kappa + source 
-    print(x[2].shape)
-    assert vmap(sim)(x).shape == torch.Size([2, n_pix, n_pix])
-    
-    # test tensor input
-    x_tensor = torch.stack(x, dim=1)
-    print(x_tensor.shape)
-    assert vmap(sim)(x_tensor).shape == torch.Size([2, n_pix, n_pix])
-    
-    # Test dictionary input: Only module with dynamic parameters are required
-    x_dict = {"cosmo": cosmo_params, "source": source_params, "lens": lens_params, "kappa": kappa}
-    print(x_dict)
-    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
-    
-    # Test passing tensor in source and kappa instead of list
-    x_dict = {"cosmo": cosmo_params, "source": source[0], "lens": lens_params, "kappa": kappa[0]}
-    print(x_dict)
-    assert vmap(sim)(x_dict).shape == torch.Size([2, n_pix, n_pix])
-    
-    # Test semantic list (one tensor per module)
-    x_semantic = [cosmo_params, lens_params, kappa, source]
-    assert vmap(sim)(x_semantic).shape == torch.Size([2, n_pix, n_pix])
 
 
 # TODO make the params attribute -> parameters and make it more intuitive
 def test_to_method():
-    sim, (cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
-    n_pix = sim.n_pix
+    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
     print(sim.params)
    
     # Check that static params have correct type 
     module = Sersic(x0=0.5)
     print(module.params.static)
-    assert module.params.static.x0.dtype == torch.float32
+    assert module.x0.dtype == torch.float32
 
     module = Sersic(x0=torch.tensor(0.5))
-    assert module.params.static.x0.dtype == torch.float32
+    assert module.x0.dtype == torch.float32
 
     module = Sersic(x0=np.array(0.5))
-    assert module.params.static.x0.dtype == torch.float32
+    assert module.x0.dtype == torch.float32
   
 
-# def test_static_param_definition():
-    # sim, (cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
+def test_parameter_redefinition():
+    sim, _ = setup_simulator()
+    
+    print(sim)
+    # Make sure the __getattribute__ method works as intended
+    assert isinstance(sim.z_s, Parameter)
+    # Now test __setattr__ method, we need to catch the redefinition here and keep z_s a parameter
+    sim.z_s = 42
+    # make sure z_s is still a parameter
+    
+    # sim.__setattr__("z_s", 42)
+    assert sim.z_s.value == torch.tensor(42).float()
+    assert sim.z_s.static is True
+    sim.z_s = None
+    assert sim.z_s.value is None
+    assert sim.z_s.dynamic is True
+    
 
 
     # # Make a test to catch parameters not in order

--- a/test/test_pixelated.py
+++ b/test/test_pixelated.py
@@ -1,10 +1,11 @@
-from caustic import Pixelated
-from caustic.utils import get_meshgrid
+# from caustic import Pixelated
+# from caustic.utils import get_meshgrid
 
 
+# TODO
 # def test_2d_pixelated_brightness():
 
-
+# TODO
 # def test_3d_pixelated_brightness():
 
 

--- a/test/test_pixelated.py
+++ b/test/test_pixelated.py
@@ -1,0 +1,11 @@
+from caustic import Pixelated
+from caustic.utils import get_meshgrid
+
+
+# def test_2d_pixelated_brightness():
+
+
+# def test_3d_pixelated_brightness():
+
+
+

--- a/test/test_pseudo_jaffe.py
+++ b/test/test_pseudo_jaffe.py
@@ -21,7 +21,7 @@ def test():
     # Parameters, computing kappa_0 with a helper function
     z_s = torch.tensor(2.1)
     x = torch.tensor([0.5, 0.071, 0.023, -1e100, 0.5, 1.5])
-    x[3] = kappa_0 = lens.convergence_0(
+    x[3] = kappa_0 = lens.central_convergence(
         x[0], z_s, torch.tensor(1.0), x[4], x[5], cosmology, defaultdict(list)
     )
     kwargs_ls = [

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Union
 
+import torch
 import numpy as np
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.LensModel.lens_model import LensModel
@@ -7,6 +8,99 @@ from lenstronomy.LensModel.lens_model import LensModel
 from caustic.lenses import ThinLens
 from caustic.lenses.base import ThickLens
 from caustic.utils import get_meshgrid
+from caustic import Simulator, EPL, Sersic, FlatLambdaCDM, Pixelated, PixelatedConvergence
+
+
+def setup_simulator(cosmo_static=False, batched_params=False):
+    n_pix = 20
+    class Sim(Simulator):
+        def __init__(self, name="test"):
+            super().__init__(name)
+            self.cosmo = FlatLambdaCDM(h0=0.7 if cosmo_static else None, name="cosmo")
+            self.epl = EPL(self.cosmo, z_l=0.5, name="lens")
+            self.sersic = Sersic(name="source")
+            self.z_s = torch.tensor(1.0)
+            self.thx, self.thy = get_meshgrid(0.04, n_pix, n_pix)
+            self.n_pix = n_pix
+
+        def forward(self, params):
+            alphax, alphay = self.epl.reduced_deflection_angle(x=self.thx, y=self.thy, z_s=self.z_s, params=params) 
+            bx = self.thx - alphax
+            by = self.thy - alphay
+            return self.sersic.brightness(bx, by, params)
+
+    # default cosmo params
+    h0 = torch.tensor([0.68, 0.75])
+    # default lens params 
+    x0 = torch.tensor([0, 0.1])
+    y0 = torch.tensor([0, 0.1])
+    q = torch.tensor([0.9, 0.8])
+    phi = torch.tensor([-0.56, 0.8])
+    b = torch.tensor([1.5, 1.2])
+    t = torch.tensor([1.2, 1.0])
+    # default source params    
+    x0s = torch.tensor([0, 0.1])
+    y0s = torch.tensor([0, 0.1])
+    qs = torch.tensor([0.9, 0.8])
+    phis = torch.tensor([-0.56, 0.8])
+    n = torch.tensor([1., 4.])
+    Re = torch.tensor([.2, .5])
+    Ie = torch.tensor([1.2, 10.])
+    
+    cosmo_params = [h0]
+    lens_params = [x0, y0, q, phi, b, t]
+    source_params = [x0s, y0s, qs, phis, n, Re, Ie]
+    if not batched_params:
+        cosmo_params = [_x[0] for _x in cosmo_params]
+        lens_params = [_x[0] for _x in lens_params]
+        source_params = [_x[0] for _x in source_params]
+    return Sim(), (cosmo_params, lens_params, source_params)
+
+
+def setup_image_simulator(cosmo_static=False, batched_params=False):
+    n_pix = 20
+    class Sim(Simulator):
+        def __init__(self, name="test"):
+            super().__init__(name)
+            pixel_scale = 0.04
+            fov = n_pix * pixel_scale
+            z_l = 0.5
+            self.z_s = torch.tensor(1.0)
+            self.cosmo = FlatLambdaCDM(h0=0.7 if cosmo_static else None, name="cosmo")
+            self.epl = EPL(self.cosmo, z_l=z_l, name="lens")
+            self.kappa = PixelatedConvergence(fov, n_pix, self.cosmo, z_l=z_l, convergence_map_shape=[n_pix, n_pix])
+            self.source = Pixelated(x0=0., y0=0., pixelscale=pixel_scale/2, image_shape=[n_pix, n_pix])
+            self.thx, self.thy = get_meshgrid(pixel_scale, n_pix, n_pix)
+            self.n_pix = n_pix
+
+        def forward(self, params):
+            alphax, alphay = self.epl.reduced_deflection_angle(x=self.thx, y=self.thy, z_s=self.z_s, params=params) 
+            alphax_h, alphay_h = self.kappa.reduced_deflection_angle(x=self.thx, y=self.thy, z_s=self.z_s, params=params)
+            bx = self.thx - alphax - alphax_h
+            by = self.thy - alphay - alphay_h
+            return self.source.brightness(bx, by, params)
+
+    # default cosmo params
+    h0 = torch.tensor([0.68, 0.75])
+    # default lens params 
+    x0 = torch.tensor([0, 0.1])
+    y0 = torch.tensor([0, 0.1])
+    q = torch.tensor([0.9, 0.8])
+    phi = torch.tensor([-0.56, 0.8])
+    b = torch.tensor([1.5, 1.2])
+    t = torch.tensor([1.2, 1.0])
+    # default kappa params
+    kappa = torch.randn([2, n_pix, n_pix])
+    source = torch.randn([2, n_pix, n_pix])
+
+    cosmo_params = [h0]
+    lens_params = [x0, y0, q, phi, b, t]
+    if not batched_params:
+        cosmo_params = [_x[0] for _x in cosmo_params]
+        lens_params = [_x[0] for _x in lens_params]
+        kappa = kappa[0]
+        source = source[0]
+    return Sim(), (cosmo_params, lens_params, [kappa], [source])
 
 
 def setup_grids(res=0.05, n_pix=100):


### PR DESCRIPTION
# Features
- Fix for batching (`vmap`) a simulator with a Pixelated source. The fix is in interp2d, line 279. This fix [Issue 53](https://github.com/Ciela-Institute/caustic/issues/53).
- Added the possibility to set a value (None or a Tensor) to a parameter at will (added a setter method to Parameter and refactored the setattr of Parametrized)
- Added test for the `to` method and verified that it works as intended. This test validates that the recursive algorithm works and that module do not necessarily have to implement a to method. This is a fix for [Issue 48](https://github.com/Ciela-Institute/caustic/issues/48)
- Made sure that default `dtype` in Paramater is `torch.float32`
- Also proposed a fix for [Issue 54](https://github.com/Ciela-Institute/caustic/issues/54) for the PseudoJaffe module.
- Added a `dtype` property to Parameter. 