### PR TITLE
base lens can now compute deflection angle jacobian

### DIFF
--- a/test/test_sie.py
+++ b/test/test_sie.py
@@ -7,6 +7,7 @@ from utils import lens_test_helper
 
 from caustic.cosmology import FlatLambdaCDM
 from caustic.lenses import SIE
+from caustic.utils import get_meshgrid
 
 
 def test():
@@ -35,6 +36,17 @@ def test():
 
     lens_test_helper(lens, lens_ls, z_s, x, kwargs_ls, rtol, atol)
 
-
+def test_jacobian():
+    # Models
+    cosmology = FlatLambdaCDM(name="cosmo")
+    lens = SIE(name="sie", cosmology=cosmology)
+    thx, thy = get_meshgrid(0.1, 10, 10)
+    
+    # Parameters
+    z_s = torch.tensor(1.2)
+    x = torch.tensor([0.5, 0.912, -0.442, 0.7, pi / 3, 1.4])
+    J = lens.jacobian_reduced_deflection_angle(thx, thy, z_s, lens.pack(x))
+    assert J.shape == (10,10,2,2)
+    
 if __name__ == "__main__":
     test()


### PR DESCRIPTION
The Jacobian of the deflection angle can be used to construct critical curves and caustics. Since `caustic` is autodifferentiable, this is really easy!