### PR TITLE
Forward raytrace in base lens class

### DIFF
--- a/caustic/forward_raytrace.py
+++ b/caustic/forward_raytrace.py
@@ -57,7 +57,7 @@ def forward_raytrace(
     thetaxy_max = torch.tensor((thetax_range[1], thetay_range[1]))
     fov = thetaxy_max - thetaxy_min
 
-    while True:
+    for _ in range(10):
         thetaxy_0s = fov[None, :] * torch.rand(n_guesses, 2) + thetaxy_min[None, :]
         thetaxys = minimize_levmarq(
             thetaxy_0s,

--- a/caustic/lenses/base.py
+++ b/caustic/lenses/base.py
@@ -327,6 +327,27 @@ class ThinLens(Parametrized):
         ax, ay = self.reduced_deflection_angle(x, y, z_s, params)
         return x - ax, y - ay
 
+    @unpack(4)
+    def forward_raytrace(
+            self, bx: Tensor, by: Tensor, z_s: Tensor, epsilon, *args, params: Optional["Packed"] = None, **kwargs
+    ) -> tuple[Tensor, Tensor]:
+        """
+        Perform a ray-tracing operation by subtracting the deflection angles from the input coordinates.
+
+        Args:
+            x (Tensor): Tensor of x coordinates in the lens plane.
+            y (Tensor): Tensor of y coordinates in the lens plane.
+            z_s (Tensor): Tensor of source redshifts.
+            epsilon (Tensor): maximum distance between two images before they are considered the same image
+            params (Packed, optional): Dynamic parameter container for the lens model. Defaults to None.
+
+        Returns:
+            tuple[Tensor, Tensor]: Ray-traced coordinates in the x and y directions.
+        """
+        
+        x, y = batch_lm(guesses, bxy, self.reduced_deflection_angle, f_args = (z_s, epsilon, params))
+        return x, y
+
     @unpack(3)
     def time_delay(
             self, x: Tensor, y: Tensor, z_s: Tensor, z_l, *args, params: Optional["Packed"] = None, **kwargs

--- a/caustic/utils.py
+++ b/caustic/utils.py
@@ -1,8 +1,10 @@
 from math import pi
 from typing import Callable, Optional, Tuple, Union
+from functools import partial
 
 import torch
 from torch import Tensor
+from torch.func import jacfwd
 
 def flip_axis_ratio(q, phi):
     """
@@ -339,18 +341,56 @@ def get_cluster_means(xs: Tensor, k: int):
 
     return torch.stack(means)
 
+def _lm_step(f, X, Y, Cinv, L, Lup, Ldn, epsilon):
+
+    # Forward
+    fY = f(X)
+    dY = Y - fY
+    
+    # Jacobian
+    J = jacfwd(f)(X)
+    J = J.to(dtype = X.dtype)
+    chi2 = (dY @ Cinv @ dY).sum(-1)
+    
+    # Gradient
+    grad = J.T @ Cinv @ dY
+    
+    # Hessian
+    hess = J.T @ Cinv @ J
+    hess_perturb = L * (torch.diag(hess) + 0.1*torch.eye(hess.shape[0]))
+    hess = hess + hess_perturb
+
+    # Step
+    h = torch.linalg.solve(hess, grad)
+    
+    # New chi^2
+    fYnew = f(X + h)
+    dYnew = Y - fYnew
+    chi2_new = (dYnew @ Cinv @ dYnew).sum(-1)
+
+    # Test
+    rho = (chi2 - chi2_new) / torch.abs(h @ (L * torch.dot(torch.diag(hess), h) + grad))
+
+    # Update
+    X = torch.where(rho >= epsilon, X + h, X)
+    chi2 = torch.where(rho > epsilon, chi2_new, chi2)
+    L = torch.clamp(torch.where(rho >= epsilon, L / Ldn, L * Lup), 1e-9, 1e9)
+
+    return X, L, chi2
+
 def batch_lm(
         X, # B, Din
         Y, # B, Dout
         f, # Din -> Dout
         C = None, # B, Dout, Dout
         epsilon = 1e-1,
-        L = 1e-2,
-        L_dn = 3.,
-        L_up = 2.,
-        max_iter = 15,
+        L = 1e0,
+        L_dn = 11.,
+        L_up = 9.,
+        max_iter = 50,
         L_min = 1e-9,
         L_max = 1e9,
+        stopping = 1e-4,
         f_args = (),
         f_kwargs = {},
 ):
@@ -364,42 +404,15 @@ def batch_lm(
         C = torch.eye(Dout).repeat(B, 1, 1)
     Cinv = torch.linalg.inv(C)
     
-    f_v = torch.vmap(lambda x: f(*x, *f_args, **f_kwargs))
-
-    J_v = torch.vmap(lambda x: torch.autograd.functional.jacobian(lambda xx: f(*xx, *f_args, **f_kwargs), x, vectorize = True, strategy = "forward-mode")[0])
-
-    fY = f_v(X)
-    chi2_prev = ((Y - fY) @ Cinv @ (Y - fY)).sum(-1)
-    ypred = f_v(X)
-
+    v_lm_step = torch.vmap(partial(_lm_step, lambda x: f(x, *f_args, **f_kwargs)))
+    L = L * torch.ones(B)
+    Lup = L_up * torch.ones(B)
+    Ldn = L_dn * torch.ones(B)
+    e = epsilon * torch.ones(B)
     for _ in range(max_iter):
-
-        # Jacobian
-        J = J_v(X)
-
-        # Gradient
-        dY = (Y - ypred)
-        grad = J.transpose(-2,-1) @ Cinv @ dY
+        Xnew, L, C = v_lm_step(X, Y, Cinv, L, Lup, Ldn, e)
+        if torch.all((Xnew - X).abs() < stopping) and torch.sum(L < 1e-2).item() > B/3:
+            break
+        X = Xnew
         
-        # Hessian
-        hess = J.transpose(-2,-1) @ Cinv @ J
-        H_perturb = L * torch.diag(hess)
-
-        # Step
-        h = torch.linalg.solve(hess + H_perturb, grad)
-
-        # New statistic
-        ynew = f_v(X + h)
-        chi2_new = ((Y - ynew) @ Cinv @ (Y - ynew)).sum(-1)
-
-        # Descision
-        rho = torch.abs(h @ (L * torch.dot(torch.diag(hess), h) + grad))
-        if (chi2_prev - chi2_new)/rho > epsilon:
-            X = X + h
-            chi2_prev = chi2_new
-            ypred = ynew
-            L = max(L / L_dn, L_min)
-        else:
-            L = min(L * L_up, L_max)
-
-    return X
+    return X, L, C

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,38 @@
+from math import pi
+
+import torch
+import numpy as np
+
+from caustic.cosmology import FlatLambdaCDM
+from caustic.lenses import SIE
+
+def test():
+
+    z_l = torch.tensor(0.5, dtype=torch.float32)
+    z_s = torch.tensor(1.5, dtype=torch.float32)
+    
+    # Model
+    cosmology = FlatLambdaCDM(name="cosmo")
+    lens = SIE(
+        name="sie",
+        cosmology=cosmology,
+        z_l = z_l,
+        x0 = torch.tensor(0.),
+        y0 = torch.tensor(0.),
+        q = torch.tensor(0.4),
+        phi = torch.tensor(np.pi/5),
+        b = torch.tensor(1.),
+    )
+    
+    # Point in the source plane
+    sp_x = torch.tensor(0.2)
+    sp_y = torch.tensor(0.2)
+    
+    # Points in image plane
+    x, y = lens.forward_raytrace(sp_x, sp_y, z_s)
+    
+    # Raytrace to check
+    bx, by = lens.raytrace(x, y, z_s)
+
+    assert torch.all((sp_x - bx).abs() < 1e-3)
+    assert torch.all((sp_y - by).abs() < 1e-3)    


### PR DESCRIPTION
Forward raytrace is now a class method for lenses. It's format is similar to raytrace, though it goes the other way. Also only a single point can be forward raytraced at a time due to the variable output shape.