### PR TITLE
Add TNFW lens

### DIFF
--- a/caustic/lenses/__init__.py
+++ b/caustic/lenses/__init__.py
@@ -11,3 +11,4 @@ from .sis import *
 from .utils import *
 from .singleplane import *
 from .mass_sheet import *
+from .tnfw import *

--- a/caustic/lenses/base.py
+++ b/caustic/lenses/base.py
@@ -308,10 +308,9 @@ class ThinLens(Parametrized):
         self.cosmology = cosmology
         self.add_param("z_l", z_l)
 
-    @abstractmethod
     @unpack(3)
     def reduced_deflection_angle(
-            self, x: Tensor, y: Tensor, z_s: Tensor, *args, params: Optional["Packed"] = None, **kwargs
+            self, x: Tensor, y: Tensor, z_s: Tensor, z_l, *args, params: Optional["Packed"] = None, **kwargs
     ) -> tuple[Tensor, Tensor]:
         """
         Computes the reduced deflection angle of the lens at given coordinates [arcsec].
@@ -325,7 +324,10 @@ class ThinLens(Parametrized):
         Returns:
             tuple[Tensor, Tensor]: Reduced deflection angle in x and y directions.
         """
-        ...
+        d_s = self.cosmology.angular_diameter_distance(z_s, params)
+        d_ls = self.cosmology.angular_diameter_distance_z1z2(z_l, z_s, params)
+        deflection_angle_x, deflection_angle_y = self.physical_deflection_angle(x, y, z_s, params)
+        return (d_ls / d_s) * deflection_angle_x, (d_ls / d_s) * deflection_angle_y
 
     @unpack(3)
     def physical_deflection_angle(

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -189,7 +189,7 @@ class TNFW(ThinLens):
         a3 = 2 * F
         a4 = - torch.pi / (t**2 + x**2).sqrt()
         a5 = (t**2 - 1) * L / (t * (t**2 + x**2).sqrt())
-        return a1 * (a2 + a3 + a4 + a5) * S / critical_density
+        return a1 * (a2 + a3 + a4 + a5) * S
 
     @unpack(0)
     def get_scale_density(self, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
@@ -224,7 +224,8 @@ class TNFW(ThinLens):
         a3 = t * torch.pi
         a4 = (t**2 - 1) * t.log()
         a5 = (t**2 + x**2).sqrt() * (-torch.pi + (t**2 - 1) * L / t)
-        return a1 * (a2 + a3 + a4 + a5)
+        S = self.get_scale_density(params) * 16 * torch.pi * self.get_scale_radius(params)**3
+        return S * a1 * (a2 + a3 + a4 + a5)
         
     @unpack(3)
     def reduced_deflection_angle(
@@ -248,8 +249,9 @@ class TNFW(ThinLens):
         d_l = self.cosmology.angular_diameter_distance(z_l, params)
         x = r * (d_l * arcsec_to_rad / self.get_scale_radius(params))
 
-        dr = self.projected_mass(r, z_s, params) / x**2
-        return dr * theta.cos(), dr * theta.sin()
+        dr = 2 * self.projected_mass(r, z_s, params) / x # note dpsi(u)/du = 2x*dpsi(x)/dx when u = x^2
+        S = 2 * G_over_c2
+        return S * dr * theta.cos(), S * dr * theta.sin()
 
     @unpack(3)
     def potential(

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -28,6 +28,16 @@ class TNFW(ThinLens):
     
     https://ui.adsabs.harvard.edu/abs/2009JCAP...01..015B/abstract
 
+    Note:
+        The mass `m` in the TNFW profile corresponds to the total mass
+        of the lens. This is different from the NFW profile where the
+        mass `m` parameter corresponds to the mass within R200. If you
+        prefer the "mass within R200" version you can set:
+        `interpret_m_total_mass = False` on initialization of the
+        object. However, the mass within R200 will be computed for an
+        NFW profile, not a TNFW profile. This is in line with how
+        lenstronomy inteprets the mass parameter.
+
     Args:
         name (str): Name of the lens instance.
         cosmology (Cosmology): An instance of the Cosmology class which contains 
@@ -44,7 +54,7 @@ class TNFW(ThinLens):
             the mass is intepreted as the total mass of the halo (good because it makes sense). If
             false it is intepreted as what the mass would have been within R200 of a an NFW that
             isn't truncated (good because it is easily compared with an NFW).
-    
+
     """
     def __init__(
         self,

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -268,7 +268,7 @@ class TNFW(ThinLens):
         x = r / rs
 
         dr = 2 * self.projected_mass(r, z_s, params) / x # note dpsi(u)/du = 2x*dpsi(x)/dx when u = x^2
-        S = 2 * G_over_c2 * rad_to_arcsec / d_l
+        S = 2 * G_over_c2 * rad_to_arcsec * d_l
         return S * dr * theta.cos(), S * dr * theta.sin()
 
     @unpack(3)
@@ -295,7 +295,8 @@ class TNFW(ThinLens):
         F = self._F(x)
         L = self._L(x, t)
 
-        S = 2 * self.get_M0(params) * G_over_c2
+        d_l = self.cosmology.angular_diameter_distance(z_l, params)
+        S = 2 * self.get_M0(params) * G_over_c2 * rad_to_arcsec * d_l**2
         a1 = 1 / (t**2 + 1)**2
         a2 = 2 * torch.pi * t**2 * (t - (t**2 + u).sqrt() + t * (t + (t**2 + u).sqrt()).log())
         a3 = 2 * (t**2 - 1) * t * (t**2 + u).sqrt() * L

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -1,0 +1,282 @@
+from math import pi
+from typing import Any, Optional, Union
+
+import torch
+from torch import Tensor
+
+from ..constants import G_over_c2, arcsec_to_rad, rad_to_arcsec
+from ..cosmology import Cosmology
+from ..utils import translate_rotate
+from .base import ThinLens
+from ..parametrized import unpack
+
+DELTA = 200.0
+
+__all__ = ("TNFW",)
+
+class TNFW(ThinLens):
+    """
+    fixme
+    
+    NFW lens class. This class models a lens using the Navarro-Frenk-White (NFW) profile.
+    The NFW profile is a spatial density profile of dark matter halo that arises in 
+    cosmological simulations.
+
+    Attributes:
+        z_l (Optional[Tensor]): Redshift of the lens. Default is None.
+        x0 (Optional[Tensor]): x-coordinate of the lens center in the lens plane. 
+            Default is None.
+        y0 (Optional[Tensor]): y-coordinate of the lens center in the lens plane. 
+            Default is None.
+        m (Optional[Tensor]): Mass of the lens. Default is None.
+        c (Optional[Tensor]): Concentration parameter of the lens. Default is None.
+        t (Optional[Tensor]): Truncation radius.
+        s (float): Softening parameter to avoid singularities at the center of the lens. 
+            Default is 0.0.
+
+    Methods:
+        get_scale_radius: Returns the scale radius of the lens.
+        get_scale_density: Returns the scale density of the lens.
+        get_convergence_s: Returns the dimensionless surface mass density of the lens.
+        _f: Helper method for computing deflection angles.
+        _g: Helper method for computing lensing potential.
+        _h: Helper method for computing reduced deflection angles.
+        deflection_angle_hat: Computes the reduced deflection angle.
+        deflection_angle: Computes the deflection angle.
+        convergence: Computes the convergence (dimensionless surface mass density).
+        potential: Computes the lensing potential.
+    """
+    def __init__(
+        self,
+        cosmology: Cosmology,
+        z_l: Optional[Union[Tensor, float]] = None,
+        x0: Optional[Union[Tensor, float]] = None,
+        y0: Optional[Union[Tensor, float]] = None,
+        m: Optional[Union[Tensor, float]] = None,
+        c: Optional[Union[Tensor, float]] = None,
+        t: Optional[Union[Tensor, float]] = None,
+        s: float = 0.0,
+        name: str = None,
+    ):
+        """
+        Initialize an instance of the NFW lens class.
+
+        Args:
+            name (str): Name of the lens instance.
+            cosmology (Cosmology): An instance of the Cosmology class which contains 
+                information about the cosmological model and parameters.
+            z_l (Optional[Union[Tensor, float]]): Redshift of the lens. Default is None.
+            x0 (Optional[Union[Tensor, float]]): x-coordinate of the lens center in the lens plane. 
+                Default is None.
+            y0 (Optional[Union[Tensor, float]]): y-coordinate of the lens center in the lens plane. 
+                Default is None.
+            m (Optional[Union[Tensor, float]]): Mass of the lens. Default is None.
+            c (Optional[Union[Tensor, float]]): Concentration parameter of the lens. Default is None.
+            s (float): Softening parameter to avoid singularities at the center of the lens. 
+                Default is 0.0.
+        """
+        super().__init__(cosmology, z_l, name=name)
+
+        self.add_param("x0", x0)
+        self.add_param("y0", y0)
+        self.add_param("m", m)
+        self.add_param("c", c)
+        self.add_param("t", t)
+        self.s = s
+
+    @staticmethod
+    def _F(x):
+        return torch.where(x == 1, torch.ones_like(x), ((1 / x.to(dtype=torch.cdouble)).arccos() / (x.to(dtype=torch.cdouble)**2 - 1).sqrt()).abs())
+
+    @staticmethod
+    def _L(x, t):
+        return (x / (t + (t**2 + x**2).sqrt())).log()
+
+    @unpack(0)
+    def get_scale_radius(self, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
+        """
+        Calculate the scale radius of the lens.
+
+        Args:
+            z_l (Tensor): Redshift of the lens.
+            m (Tensor): Mass of the lens.
+            c (Tensor): Concentration parameter of the lens.
+            x (dict): Dynamic parameter container.
+
+        Returns:
+            Tensor: The scale radius of the lens in Mpc.
+        """
+        critical_density = self.cosmology.critical_density(z_l, params)
+        r_delta = (3 * m / (4 * pi * DELTA * critical_density)) ** (1 / 3)
+        return 1 / c * r_delta
+
+    @unpack(0)
+    def get_truncation_radius(self, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
+        """
+        Calculate the truncation radius of the TNFW lens.
+
+        Args:
+            z_l (Tensor): Redshift of the lens.
+            m (Tensor): Mass of the lens.
+            c (Tensor): Concentration parameter of the lens.
+            x (dict): Dynamic parameter container.
+
+        Returns:
+            Tensor: The truncation radius of the lens in Mpc.
+        """
+        return t * self.get_scale_radius(params)
+
+
+    @unpack(0)
+    def get_scale_density(self, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
+        """
+        Calculate the scale density of the lens.
+
+        Args:
+            z_l (Tensor): Redshift of the lens.
+            c (Tensor): Concentration parameter of the lens.
+            params (Packed, optional): Dynamic parameter container.
+
+        Returns:
+            Tensor: The scale density of the lens in solar masses per Mpc cubed.
+        """
+        return (
+            DELTA
+            / 3
+            * self.cosmology.critical_density(z_l, params)
+            * c**3
+            / ((1 + c).log() - c / (1 + c))
+        )
+
+    @unpack(1)
+    def get_convergence_s(self, z_s, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
+        """
+        Calculate the dimensionless surface mass density of the lens.
+
+        Args:
+            z_l (Tensor): Redshift of the lens.
+            z_s (Tensor): Redshift of the source.
+            m (Tensor): Mass of the lens.
+            c (Tensor): Concentration parameter of the lens.
+            params (Packed, optional): Dynamic parameter container.
+
+        Returns:
+            Tensor: The dimensionless surface mass density of the lens.
+        """
+        critical_surface_density = self.cosmology.critical_surface_density(z_l, z_s, params)
+        return self.get_scale_density(params) * self.get_scale_radius(params) / critical_surface_density
+    
+
+    @unpack(3)
+    def convergence(
+            self, x: Tensor, y: Tensor, z_s: Tensor, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs
+    ) -> Tensor:
+        x, y = translate_rotate(x, y, x0, y0)
+        r = (x**2 + y**2).sqrt() + self.s
+        d_l = self.cosmology.angular_diameter_distance(z_l, params)
+        x = r * (d_l * arcsec_to_rad / self.get_scale_radius(params))
+        F = self._F(x)
+        L = self._L(x, t)
+        critical_density = self.cosmology.critical_density(z_l, params)
+
+        S = self.get_convergence_s(z_s, params) / 8.
+        a1 = t**2 / (t**2 + 1)**2
+        a2 = (t**2 + 1) * (1 - F) / (x**2 - 1)
+        a3 = 2 * F
+        a4 = - torch.pi / (t**2 + x**2).sqrt()
+        a5 = (t**2 - 1) * L / (t * (t**2 + x**2).sqrt())
+        return a1 * (a2 + a3 + a4 + a5) * S / critical_density
+
+    @unpack(0)
+    def get_scale_density(self, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs) -> Tensor:
+        """
+        Calculate the scale density of the lens.
+
+        Args:
+            z_l (Tensor): Redshift of the lens.
+            c (Tensor): Concentration parameter of the lens.
+            params (Packed, optional): Dynamic parameter container.
+
+        Returns:
+            Tensor: The scale density of the lens in solar masses per Mpc cubed.
+        """
+        return (
+            DELTA
+            / 3
+            * self.cosmology.critical_density(z_l, params)
+            * c**3
+            / ((1 + c).log() - c / (1 + c))
+        )
+
+    @unpack(2)
+    def projected_mass(
+            self, r: Tensor, z_s: Tensor, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs
+    ) -> Tensor:
+        x = r / self.get_scale_radius(params)
+        F = self._F(x)
+        L = self._L(x, t)
+        a1 = t**2 / (t**2 + 1)**2
+        a2 = (t**2 + 1 + 2*(x**2 - 1)) * F
+        a3 = t * torch.pi
+        a4 = (t**2 - 1) * t.log()
+        a5 = (t**2 + x**2).sqrt() * (-torch.pi + (t**2 - 1) * L / t)
+        return a1 * (a2 + a3 + a4 + a5)
+        
+    @unpack(3)
+    def reduced_deflection_angle(
+            self, x: Tensor, y: Tensor, z_s: Tensor, z_l, x0, y0, m, c, t, *args, params: Optional["Packed"] = None, **kwargs
+    ) -> tuple[Tensor, Tensor]:
+        """
+        Compute the reduced deflection angle.
+
+        Args:
+            x (Tensor): x-coordinates in the lens plane.
+            y (Tensor): y-coordinates in the lens plane.
+            z_s (Tensor): Redshifts of the sources.
+            params (Packed, optional): Dynamic parameter container.
+
+        Returns:
+            tuple[Tensor, Tensor]: The reduced deflection angles in the x and y directions.
+        """
+        x, y = translate_rotate(x, y, x0, y0)
+        r = (x**2 + y**2).sqrt() + self.s
+        theta = torch.arctan2(y,x)
+        d_l = self.cosmology.angular_diameter_distance(z_l, params)
+        x = r * (d_l * arcsec_to_rad / self.get_scale_radius(params))
+
+        dr = self.projected_mass(r, z_s, params) / x**2
+        return dr * theta.cos(), dr * theta.sin()
+
+    @unpack(3)
+    def potential(
+        self, x: Tensor, y: Tensor, z_s: Tensor, z_l, x0, y0, m, c, *args, params: Optional["Packed"] = None, **kwargs
+    ) -> Tensor:
+        """
+        Compute the lensing potential.
+
+        Args:
+            x (Tensor): x-coordinates in the lens plane.
+            y (Tensor): y-coordinates in the lens plane.
+            z_s (Tensor): Redshifts of the sources.
+            params (Packed, optional): Dynamic parameter container.
+
+        Returns:
+            Tensor: The lensing potential.
+        """
+        x, y = translate_rotate(x, y, x0, y0)
+        r = (x**2 + y**2).sqrt() + self.s
+        x = r / self.get_scale_radius(params)
+        u = x**2
+        F = self._F(x)
+        L = self._L(x, t)
+        
+        a1 = 1 / (t**2 + 1)**2
+        a2 = 2 * torch.pi * t**2 * (t - (t**2 + u).sqrt() + t * (t + (t**2 + u).sqrt()).log())
+        a3 = 2 * (t**2 - 1) * t * (t**2 + u).sqrt() * L
+        a4 = t**2 * (t**2 - 1) * L**2
+        a5 = 4 * t**2 * (u - 1) * F
+        a6 = t**2 * (t**2 - 1) * (1 / x).arccos()**2
+        a7 = t**2 * ((t**2 - 1) * t.log() - t**2 - 1) * u.log()
+        a8 = t**2 * ((t**2 - 1) * t.log() * (4*t).log() + 2 * (t/2).log() - 2 * t * (t - torch.pi) * (2*t).log())
+
+        return a1 * (a2 + a3 + a4 + a5 + a6 + a7 + a8)

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -15,12 +15,15 @@ DELTA = 200.0
 __all__ = ("TNFW",)
 
 class TNFW(ThinLens):
-    """
-    fixme
+    """fixme
     
-    NFW lens class. This class models a lens using the Navarro-Frenk-White (NFW) profile.
-    The NFW profile is a spatial density profile of dark matter halo that arises in 
-    cosmological simulations.
+    TNFW lens class. This class models a lens using the truncated
+    Navarro-Frenk-White (NFW) profile.  The NFW profile is a spatial
+    density profile of dark matter halo that arises in cosmological
+    simulations. It is truncated with an extra scaling term which
+    smoothly reduces the density such that it does not diverge to
+    infinity. This is based off the paper by Baltz et al. 2008:
+    https://arxiv.org/abs/0705.0682
 
     Attributes:
         z_l (Optional[Tensor]): Redshift of the lens. Default is None.
@@ -30,7 +33,7 @@ class TNFW(ThinLens):
             Default is None.
         m (Optional[Tensor]): Mass of the lens. Default is None.
         c (Optional[Tensor]): Concentration parameter of the lens. Default is None.
-        t (Optional[Tensor]): Truncation radius.
+        t (Optional[Tensor]): Truncation scale (t = truncation radius / scale radius).
         s (float): Softening parameter to avoid singularities at the center of the lens. 
             Default is 0.0.
 
@@ -45,6 +48,7 @@ class TNFW(ThinLens):
         deflection_angle: Computes the deflection angle.
         convergence: Computes the convergence (dimensionless surface mass density).
         potential: Computes the lensing potential.
+
     """
     def __init__(
         self,

--- a/test/test_tnfw.py
+++ b/test/test_tnfw.py
@@ -69,9 +69,8 @@ def test_runs():
     x = torch.tensor([thx0, thy0, m, c, t])
     
     thx, thy, thx_ls, thy_ls = setup_grids()
-    alpha_x, alpha_y = lens.reduced_deflection_angle(thx, thy, z_s, lens.pack(x))
-    assert torch.all(torch.isfinite(alpha_x))
-    assert torch.all(torch.isfinite(alpha_y))
+    kappa = lens.convergence(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(kappa))
     
     Psi = lens.potential(thx, thy, z_s, lens.pack(x))
     assert torch.all(torch.isfinite(Psi))

--- a/test/test_tnfw.py
+++ b/test/test_tnfw.py
@@ -1,0 +1,81 @@
+# from math import pi
+
+# import lenstronomy.Util.param_util as param_util
+import torch
+from astropy.cosmology import FlatLambdaCDM as FlatLambdaCDM_AP
+from astropy.cosmology import default_cosmology
+
+# next three imports to get Rs_angle and alpha_Rs in arcsec for lenstronomy
+from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+from lenstronomy.LensModel.lens_model import LensModel
+from utils import lens_test_helper, setup_grids
+
+from caustic.cosmology import FlatLambdaCDM as CausticFlatLambdaCDM
+from caustic.lenses import TNFW
+
+h0_default = float(default_cosmology.get().h)
+Om0_default = float(default_cosmology.get().Om0)
+Ob0_default = float(default_cosmology.get().Ob0)
+
+
+def test():
+    atol = 1e-5
+    rtol = 3e-2
+
+    # Models
+    cosmology = CausticFlatLambdaCDM(name="cosmo")
+    z_l = torch.tensor(0.1)
+    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l)
+    lens_model_list = ["TNFW"]
+    lens_ls = LensModel(lens_model_list=lens_model_list)
+
+    print(lens)
+
+    # Parameters
+    z_s = torch.tensor(0.5)
+
+    thx0 = 0.457
+    thy0 = 0.141
+    m = 1e12
+    c = 8.0
+    t = 3.0
+    x = torch.tensor([thx0, thy0, m, c, t])
+    
+    # Lenstronomy
+    cosmo = FlatLambdaCDM_AP(H0=h0_default * 100, Om0=Om0_default, Ob0=Ob0_default)
+    lens_cosmo = LensCosmo(z_lens=z_l.item(), z_source=z_s.item(), cosmo=cosmo)
+    Rs_angle, alpha_Rs = lens_cosmo.nfw_physical2angle(M=m, c=c)
+
+    # lenstronomy params ['Rs', 'alpha_Rs', 'center_x', 'center_y']
+    kwargs_ls = [
+        {"Rs": Rs_angle, "alpha_Rs": alpha_Rs, "r_trunc": alpha_Rs * t, "center_x": thx0, "center_y": thy0}
+    ]
+
+    lens_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol, test_Psi = False, test_kappa = False)
+
+def test_runs():
+    cosmology = CausticFlatLambdaCDM(name="cosmo")
+    z_l = torch.tensor(0.1)
+    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l)
+    
+    # Parameters
+    z_s = torch.tensor(0.5)
+
+    thx0 = 0.457
+    thy0 = 0.141
+    m = 1e12
+    c = 8.0
+    t = 3.0
+    x = torch.tensor([thx0, thy0, m, c, t])
+    
+    thx, thy, thx_ls, thy_ls = setup_grids()
+    alpha_x, alpha_y = lens.reduced_deflection_angle(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(alpha_x))
+    assert torch.all(torch.isfinite(alpha_y))
+    
+    Psi = lens.potential(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(Psi))
+
+
+if __name__ == "__main__":
+    test()

--- a/test/test_tnfw.py
+++ b/test/test_tnfw.py
@@ -25,7 +25,7 @@ def test():
     # Models
     cosmology = CausticFlatLambdaCDM(name="cosmo")
     z_l = torch.tensor(0.1)
-    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l)
+    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l, interpret_m_total_mass = False)
     lens_model_list = ["TNFW"]
     lens_ls = LensModel(lens_model_list=lens_model_list)
 
@@ -48,10 +48,10 @@ def test():
 
     # lenstronomy params ['Rs', 'alpha_Rs', 'center_x', 'center_y']
     kwargs_ls = [
-        {"Rs": Rs_angle, "alpha_Rs": alpha_Rs, "r_trunc": alpha_Rs * t, "center_x": thx0, "center_y": thy0}
+        {"Rs": Rs_angle, "alpha_Rs": alpha_Rs, "r_trunc": Rs_angle * t, "center_x": thx0, "center_y": thy0}
     ]
 
-    lens_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol, test_Psi = False, test_kappa = False)
+    lens_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol, test_alpha = True, test_Psi = False, test_kappa = True)
 
 def test_runs():
     cosmology = CausticFlatLambdaCDM(name="cosmo")
@@ -69,8 +69,6 @@ def test_runs():
     x = torch.tensor([thx0, thy0, m, c, t])
     
     thx, thy, thx_ls, thy_ls = setup_grids()
-    kappa = lens.convergence(thx, thy, z_s, lens.pack(x))
-    assert torch.all(torch.isfinite(kappa))
     
     Psi = lens.potential(thx, thy, z_s, lens.pack(x))
     assert torch.all(torch.isfinite(Psi))

--- a/test/utils.py
+++ b/test/utils.py
@@ -163,6 +163,7 @@ def kappa_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol):
     thx, thy, thx_ls, thy_ls = setup_grids()
     kappa = lens.convergence(thx, thy, z_s, lens.pack(x))
     kappa_ls = lens_ls.kappa(thx_ls, thy_ls, kwargs_ls)
+    print(kappa / kappa_ls)
     assert np.allclose(kappa.numpy(), kappa_ls, rtol, atol)
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -163,7 +163,6 @@ def kappa_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol):
     thx, thy, thx_ls, thy_ls = setup_grids()
     kappa = lens.convergence(thx, thy, z_s, lens.pack(x))
     kappa_ls = lens_ls.kappa(thx_ls, thy_ls, kwargs_ls)
-    print(kappa / kappa_ls)
     assert np.allclose(kappa.numpy(), kappa_ls, rtol, atol)
 
 


### PR DESCRIPTION
Adding the TNFW lensing profile as described by Baltz et al. 2008 Equation A.3.

The convergence has been normalized by Sigma_crit. The deflection angles have been adjusted to the proper units. The potential is left in the un-reduced version from the source.