### PR TITLE
Fix to pixelated FFT with no padding

### DIFF
--- a/caustic/lenses/pixelated_convergence.py
+++ b/caustic/lenses/pixelated_convergence.py
@@ -146,8 +146,7 @@ class PixelatedConvergence(ThinLens):
         elif self.padding == "tile":
             x = torch.tile(x, (2,2))
 
-        self.pretype = x.dtype
-        return torch.fft.rfft2(x.to(dtype=torch.float64), self._s)
+        return torch.fft.rfft2(x, self._s)
     
     def _unpad_fft(self, x: Tensor) -> Tensor:
         """
@@ -159,7 +158,7 @@ class PixelatedConvergence(ThinLens):
         Returns:
             Tensor: The input tensor without padding.
         """
-        return torch.roll(x.to(dtype=self.pretype), (-self._s[0]//2,-self._s[1]//2), dims = (-2,-1))[..., :self.n_pix, :self.n_pix]
+        return torch.roll(x, (-self._s[0]//2,-self._s[1]//2), dims = (-2,-1))[..., :self.n_pix, :self.n_pix]
 
     def _unpad_conv2d(self, x: Tensor) -> Tensor:
         """
@@ -193,9 +192,9 @@ class PixelatedConvergence(ThinLens):
         """
         if convolution_mode == "fft":
             # Create FFTs of kernels
-            self.potential_kernel_tilde = self._fft2_padded(self.potential_kernel.to(dtype = torch.float64))
-            self.ax_kernel_tilde = self._fft2_padded(self.ax_kernel.to(dtype = torch.float64))
-            self.ay_kernel_tilde = self._fft2_padded(self.ay_kernel.to(dtype = torch.float64))
+            self.potential_kernel_tilde = self._fft2_padded(self.potential_kernel)
+            self.ax_kernel_tilde = self._fft2_padded(self.ax_kernel)
+            self.ay_kernel_tilde = self._fft2_padded(self.ay_kernel)
         elif convolution_mode == "conv2d":
             # Drop FFTs of kernels
             self.potential_kernel_tilde = None
@@ -246,7 +245,7 @@ class PixelatedConvergence(ThinLens):
         Returns:
             tuple[Tensor, Tensor]: The x and y components of the deflection angles.
         """
-        convergence_tilde = self._fft2_padded(convergence_map.to(dtype = torch.float64))
+        convergence_tilde = self._fft2_padded(convergence_map)
         deflection_angle_x = torch.fft.irfft2(convergence_tilde * self.ax_kernel_tilde, self._s).real * (
             self.pixelscale**2 / pi
         )

--- a/caustic/lenses/pixelated_convergence.py
+++ b/caustic/lenses/pixelated_convergence.py
@@ -267,7 +267,7 @@ class PixelatedConvergence(ThinLens):
         # Use convergence_map as kernel since the kernel is twice as large. Flip since
         # we actually want the cross-correlation.
         
-        pad = int((1. + self.padding_range) * self.n_pix)
+        pad = 2 * self.n_pix
         convergence_map_flipped = convergence_map.flip((-1, -2))[None, None] # F.pad(, ((pad - self.n_pix)//2, (pad - self.n_pix)//2, (pad - self.n_pix)//2, (pad - self.n_pix)//2), mode = self.padding_mode)
         deflection_angle_x = F.conv2d(self.ax_kernel[None, None], convergence_map_flipped, padding = "same").squeeze() * (
             self.pixelscale**2 / pi

--- a/caustic/lenses/pixelated_convergence.py
+++ b/caustic/lenses/pixelated_convergence.py
@@ -53,10 +53,10 @@ class PixelatedConvergence(ThinLens):
             use_next_fast_len (bool, optional): If True, adds additional padding to speed up the FFT by calling
                 `scipy.fft.next_fast_len`. The speed boost can be substantial when `n_pix` is a multiple of a
                 small prime number. Default is True.
-            padding_range (Optional[float]): This is the amount of padding to add in units of the image size n_pix. A value
-                of 0 means no padding (useful for periodic mass sheet), 1 means padding equal to the size of the image (default).
-            padding_mode (str): Specifies the type of padding to use. "constant" will do zero padding, "circular" will do
-                cyclic boundaries. This mode is not yet fully implemented and is only included for testing.
+            padding (str): Specifies the type of padding to use. "zero" will do zero padding, "circular" will do
+                cyclic boundaries. "reflect" will do reflection padding. "tile" will tile the image at 2x2 which
+                basically identical to circular padding, but is easier. Generally you should use either "zero"
+                or "tile".
 
         """
         


### PR DESCRIPTION
No padding is actually illegal, need to have kernel at 2x image size. So now we pad by tiling the image to maintain the infinite periodic field feature.