### PR TITLE
Fix nan gradients in NFW and TNFW

### DIFF
--- a/caustic/lenses/nfw.py
+++ b/caustic/lenses/nfw.py
@@ -148,15 +148,10 @@ class NFW(ThinLens):
             Tensor: Result of the deflection angle computation.
         """
         # TODO: generalize beyond torch, or patch Tensor
-        return torch.where(
-            x > 1,
-            1 - 2 / (x**2 - 1).sqrt() * ((x - 1) / (x + 1)).sqrt().arctan(),
-            torch.where(
-                x < 1,
-                1 - 2 / (1 - x**2).sqrt() * ((1 - x) / (1 + x)).sqrt().arctanh(),
-                0.0,
-            ),
-        )
+        f = torch.zeros_like(x)
+        f[x > 1] = 1 - 2 / (x[x > 1]**2 - 1).sqrt() * ((x[x > 1] - 1) / (x[x > 1] + 1)).sqrt().arctan()
+        f[x < 1] = 1 - 2 / (1 - x[x < 1]**2).sqrt() * ((1 - x[x < 1]) / (1 + x[x < 1])).sqrt().arctanh()
+        return f
 
     @staticmethod
     def _g(x: Tensor) -> Tensor:
@@ -171,11 +166,9 @@ class NFW(ThinLens):
         """
         # TODO: generalize beyond torch, or patch Tensor
         term_1 = (x / 2).log() ** 2
-        term_2 = torch.where(
-            x > 1,
-            (1 / x).arccos() ** 2,
-            torch.where(x < 1, -(1 / x).arccosh() ** 2, 0.0),
-        )
+        term_2 = torch.zeros_like(x)
+        term_2[x > 1] = (1 / x[x > 1]).arccos() ** 2
+        term_2[x < 1] = -(1 / x).arccosh() ** 2
         return term_1 + term_2
 
     @staticmethod
@@ -190,16 +183,10 @@ class NFW(ThinLens):
             Tensor: Result of the reduced deflection angle computation.
         """
         term_1 = (x / 2).log()
-        term_2 = torch.where(
-            x > 1,
-            term_1 + (1 / x).arccos() * 1 / (x**2 - 1).sqrt(),
-            torch.where(
-                x < 1,
-                term_1 + (1 / x).arccosh() * 1 / (1 - x**2).sqrt(),
-                1.0 + torch.tensor(1 / 2).log(),
-            ),
-        )
-        return term_2
+        term_2 = torch.ones_like(x)
+        term_2[x > 1] = (1 / x[x > 1]).arccos() * 1 / (x[x > 1]**2 - 1).sqrt()
+        term_2[x < 1] = (1 / x[x < 1]).arccosh() * 1 / (1 - x[x < 1]**2).sqrt()
+        return term_1 + term_2
 
     @unpack(3)
     def reduced_deflection_angle(

--- a/caustic/lenses/nfw.py
+++ b/caustic/lenses/nfw.py
@@ -168,7 +168,7 @@ class NFW(ThinLens):
         term_1 = (x / 2).log() ** 2
         term_2 = torch.zeros_like(x)
         term_2[x > 1] = (1 / x[x > 1]).arccos() ** 2
-        term_2[x < 1] = -(1 / x).arccosh() ** 2
+        term_2[x < 1] = -(1 / x[x < 1]).arccosh() ** 2
         return term_1 + term_2
 
     @staticmethod

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -88,8 +88,11 @@ class TNFW(ThinLens):
         """
         Helper method from Baltz et al. 2009 equation A.5
         """
-        return torch.where(x == 1, torch.ones_like(x), ((1 / x.to(dtype=torch.cdouble)).arccos() / (x.to(dtype=torch.cdouble)**2 - 1).sqrt()).abs())
-
+        f = torch.ones_like(x)
+        f[x < 1] = torch.arctanh((1. - x[x < 1]**2).sqrt()) / (1. - x[x < 1]**2).sqrt()
+        f[x > 1] = torch.arctan((x[x > 1]**2 - 1.).sqrt()) / (x[x > 1]**2 - 1.).sqrt()
+        return f
+    
     @staticmethod
     def _L(x, tau):
         """

--- a/caustic/lenses/tnfw.py
+++ b/caustic/lenses/tnfw.py
@@ -54,6 +54,9 @@ class TNFW(ThinLens):
             the mass is intepreted as the total mass of the halo (good because it makes sense). If
             false it is intepreted as what the mass would have been within R200 of a an NFW that
             isn't truncated (good because it is easily compared with an NFW).
+        use_case (str): Due to an idyosyncratic behaviour of PyTorch, the NFW/TNFW profile
+            specifically cant be both batchable and differentiable. You may select which version
+            you wish to use by setting this parameter to one of: batchable, differentiable.
 
     """
     def __init__(

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -12,7 +12,7 @@ from .packed import Packed
 from .namespace_dict import NamespaceDict, NestedNamespaceDict
 from .parameter import Parameter
 
-__all__ = ("Parametrized",)
+__all__ = ("Parametrized","unpack")
 
 class Parametrized:
     """

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -4,7 +4,7 @@ from utils import setup_image_simulator, setup_simulator
 import pytest
 
 def test_vmapped_simulator():
-    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True, use_nfw = False)
+    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
     n_pix = sim.n_pix
     print(sim.params)
  

--- a/test/test_batching.py
+++ b/test/test_batching.py
@@ -4,7 +4,7 @@ from utils import setup_image_simulator, setup_simulator
 import pytest
 
 def test_vmapped_simulator():
-    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True)
+    sim, (sim_params, cosmo_params, lens_params, source_params) = setup_simulator(batched_params=True, use_nfw = False)
     n_pix = sim.n_pix
     print(sim.params)
  

--- a/test/test_nfw.py
+++ b/test/test_nfw.py
@@ -70,6 +70,12 @@ def test_runs():
     
     Psi = lens.potential(thx, thy, z_s, lens.pack(x))
     assert torch.all(torch.isfinite(Psi))
+    alpha = lens.reduced_deflection_angle(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(alpha[0]))
+    assert torch.all(torch.isfinite(alpha[1]))
+    kappa = lens.convergence(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(kappa))
+    
 
 if __name__ == "__main__":
     test()

--- a/test/test_nfw.py
+++ b/test/test_nfw.py
@@ -8,7 +8,7 @@ from astropy.cosmology import default_cosmology
 # next three imports to get Rs_angle and alpha_Rs in arcsec for lenstronomy
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.LensModel.lens_model import LensModel
-from utils import lens_test_helper
+from utils import lens_test_helper, setup_grids
 
 from caustic.cosmology import FlatLambdaCDM as CausticFlatLambdaCDM
 from caustic.lenses import NFW
@@ -52,6 +52,24 @@ def test():
 
     lens_test_helper(lens, lens_ls, z_s, x, kwargs_ls, atol, rtol)
 
+def test_runs():
+    cosmology = CausticFlatLambdaCDM(name="cosmo")
+    z_l = torch.tensor(0.1)
+    lens = NFW(name="nfw", cosmology=cosmology, z_l=z_l, use_case = "differentiable")
+    
+    # Parameters
+    z_s = torch.tensor(0.5)
+
+    thx0 = 0.457
+    thy0 = 0.141
+    m = 1e12
+    rs = 8.0
+    x = torch.tensor([thx0, thy0, m, rs])
+    
+    thx, thy, thx_ls, thy_ls = setup_grids()
+    
+    Psi = lens.potential(thx, thy, z_s, lens.pack(x))
+    assert torch.all(torch.isfinite(Psi))
 
 if __name__ == "__main__":
     test()

--- a/test/test_tnfw.py
+++ b/test/test_tnfw.py
@@ -45,7 +45,6 @@ def test():
     cosmo = FlatLambdaCDM_AP(H0=h0_default * 100, Om0=Om0_default, Ob0=Ob0_default)
     lens_cosmo = LensCosmo(z_lens=z_l.item(), z_source=z_s.item(), cosmo=cosmo)
     Rs_angle, alpha_Rs = lens_cosmo.nfw_physical2angle(M=m, c=c)
-    print(Rs_angle)
     x[3] = Rs_angle
 
     # lenstronomy params ['Rs', 'alpha_Rs', 'center_x', 'center_y']

--- a/test/test_tnfw.py
+++ b/test/test_tnfw.py
@@ -57,7 +57,7 @@ def test():
 def test_runs():
     cosmology = CausticFlatLambdaCDM(name="cosmo")
     z_l = torch.tensor(0.1)
-    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l)
+    lens = TNFW(name="tnfw", cosmology=cosmology, z_l=z_l, use_case = "differentiable")
     
     # Parameters
     z_s = torch.tensor(0.5)


### PR DESCRIPTION
It turns out that `torch.where` does not protect from nans in the off branch. The condition is applied by multiplication, something like:

`torch.where(x < 1, A, B)` is the same as `A * (x < 1) + B * (x >= 1)`

So nan's are somehow magically avoided in the forward pass when they probably shouldn't be, but in the backward pass there is no avoiding them.

So I made two versions of each offending function and the user can now select whether they want to batch, or get derivatives.