### PR TITLE
Bug fixes 20231008

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -37,6 +37,8 @@ jobs:
         # Install deps
         cd $GITHUB_WORKSPACE
         pip install -r requirements.txt
+        pip list
+        pip show astropy
       shell: bash
     - name: Install Caustic
       run: |

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -39,6 +39,7 @@ jobs:
         pip install -r requirements.txt
         pip list
         pip show astropy
+        pip install astropy
       shell: bash
     - name: Install Caustic
       run: |

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,21 +30,20 @@ jobs:
         echo github.event_name is: ${{ github.event_name }}
         echo github workspace: ${{ github.workspace }}
         pip --version
+        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov torch
+        pip install pytest pytest-cov torch wheel
         # Install deps
         cd $GITHUB_WORKSPACE
         pip install -r requirements.txt
-        pip list
-        pip show astropy
-        pip install astropy
       shell: bash
+      
     - name: Install Caustic
       run: |
         cd $GITHUB_WORKSPACE
-        pip install -e .
+        pip install -e .[dev]
         pip show caustic
       shell: bash
     - name: Test with pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,15 +46,13 @@ jobs:
         pip install pytest pytest-cov torch wheel
         # Install deps
         cd $GITHUB_WORKSPACE
-        cat requirements.txt
-        ls
         pip install -r requirements.txt
       shell: bash
 
     - name: Install Caustic
       run: |
         cd $GITHUB_WORKSPACE
-        pip install -e .
+        pip install -e .[dev]
         pip show caustic
       shell: bash
 

--- a/caustic/cosmology.py
+++ b/caustic/cosmology.py
@@ -210,6 +210,11 @@ class FlatLambdaCDM(Cosmology):
         self._comoving_distance_helper_y_grid = _comoving_distance_helper_y_grid.to(
             dtype=torch.float32
         )
+    
+    def to(self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None):
+        super().to(device, dtype)
+        self._comoving_distance_helper_y_grid = self._comoving_distance_helper_y_grid.to(device, dtype)
+        self._comoving_distance_helper_x_grid = self._comoving_distance_helper_x_grid.to(device, dtype)
 
     def hubble_distance(self, h0):
         """

--- a/caustic/lenses/base.py
+++ b/caustic/lenses/base.py
@@ -165,7 +165,7 @@ class ThickLens(Parametrized):
         ax, ay = self.effective_reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2))
+        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
         J[...,0,1], J[...,0,0] = torch.gradient(ax, spacing = pixelscale)
         J[...,1,1], J[...,1,0] = torch.gradient(ay, spacing = pixelscale)
         return J
@@ -185,7 +185,7 @@ class ThickLens(Parametrized):
         ax, ay = self.effective_reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2))
+        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
         J[...,0,0], = torch.autograd.grad(ax, x, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,0,1], = torch.autograd.grad(ax, y, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,1,0], = torch.autograd.grad(ay, x, grad_outputs = torch.ones_like(ay), create_graph = True)
@@ -512,7 +512,7 @@ class ThinLens(Parametrized):
         ax, ay = self.reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2))
+        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
         J[...,0,1], J[...,0,0] = torch.gradient(ax, spacing = pixelscale)
         J[...,1,1], J[...,1,0] = torch.gradient(ay, spacing = pixelscale)
         return J
@@ -532,7 +532,7 @@ class ThinLens(Parametrized):
         ax, ay = self.reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2))
+        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
         J[...,0,0], = torch.autograd.grad(ax, x, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,0,1], = torch.autograd.grad(ax, y, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,1,0], = torch.autograd.grad(ay, x, grad_outputs = torch.ones_like(ay), create_graph = True)

--- a/caustic/lenses/base.py
+++ b/caustic/lenses/base.py
@@ -165,7 +165,7 @@ class ThickLens(Parametrized):
         ax, ay = self.effective_reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
+        J = torch.zeros((*ax.shape, 2, 2), device=ax.device, dtype=ax.dtype)
         J[...,0,1], J[...,0,0] = torch.gradient(ax, spacing = pixelscale)
         J[...,1,1], J[...,1,0] = torch.gradient(ay, spacing = pixelscale)
         return J
@@ -185,7 +185,7 @@ class ThickLens(Parametrized):
         ax, ay = self.effective_reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
+        J = torch.zeros((*ax.shape, 2, 2), device=ax.device, dtype=ax.dtype)
         J[...,0,0], = torch.autograd.grad(ax, x, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,0,1], = torch.autograd.grad(ax, y, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,1,0], = torch.autograd.grad(ay, x, grad_outputs = torch.ones_like(ay), create_graph = True)
@@ -512,7 +512,7 @@ class ThinLens(Parametrized):
         ax, ay = self.reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
+        J = torch.zeros((*ax.shape, 2, 2), device=ax.device, dtype=ax.dtype)
         J[...,0,1], J[...,0,0] = torch.gradient(ax, spacing = pixelscale)
         J[...,1,1], J[...,1,0] = torch.gradient(ay, spacing = pixelscale)
         return J
@@ -532,7 +532,7 @@ class ThinLens(Parametrized):
         ax, ay = self.reduced_deflection_angle(x, y, z_s, params)
 
         # Build Jacobian
-        J = torch.zeros((*ax.shape, 2, 2)).to(device=ax.device, dtype=ax.dtype)
+        J = torch.zeros((*ax.shape, 2, 2), device=ax.device, dtype=ax.dtype)
         J[...,0,0], = torch.autograd.grad(ax, x, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,0,1], = torch.autograd.grad(ax, y, grad_outputs = torch.ones_like(ax), create_graph = True)
         J[...,1,0], = torch.autograd.grad(ay, x, grad_outputs = torch.ones_like(ay), create_graph = True)

--- a/caustic/parameter.py
+++ b/caustic/parameter.py
@@ -80,6 +80,6 @@ class Parameter:
 
     def __repr__(self) -> str:
         if self.static:
-            return f"Param(value={self.value}, dtype={str(self.dtype)[-1]})"
+            return f"Param(value={self.value}, dtype={str(self.dtype)})"
         else:
             return f"Param(shape={self.shape})"

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -450,7 +450,7 @@ def unpack(n_leading_args=0):
                     # params were part of a collection already (don't double wrap them)
                     x = self.pack(trailing_args[0])
                 else:
-                    # all parameters were passed indiviually in args or kwargs
+                    # all parameters were passed individually in args or kwargs
                     x = self.pack(trailing_args)
             unpacked_args = self.unpack(x)
             kwargs['params'] = x

--- a/caustic/parametrized.py
+++ b/caustic/parametrized.py
@@ -413,7 +413,6 @@ def unpack(n_leading_args=0):
     def decorator(method):
         sig = inspect.signature(method)
         method_params = list(sig.parameters.keys())[1:]  # exclude 'self'
-        print(method_params)
         n_params = len(method_params)
 
         @functools.wraps(method)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-astropy>=5.2.1
 graphviz==0.20.1
 h5py>=3.8.0
 levmarq_torch==0.0.1
 numpy>=1.23.5
 scipy>=1.8.0
 torch>=2.0.0
+astropy>=5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 astropy>=5.2.1
 graphviz==0.20.1
 h5py>=3.8.0
-lenstronomy==1.11.1
 levmarq_torch==0.0.1
 numpy>=1.23.5
 scipy>=1.8.0
-setuptools>=67.2.0
 torch>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-astropy==5.2.1
+astropy>=5.2.1
 graphviz==0.20.1
-h5py==3.8.0
+h5py>=3.8.0
 lenstronomy==1.11.1
 levmarq_torch==0.0.1
-numpy==1.23.5
-scipy==1.8.0
-setuptools==67.2.0
-torch==2.0.0
+numpy>=1.23.5
+scipy>=1.8.0
+setuptools>=67.2.0
+torch>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ setup(
     license="MIT license",
     packages=find_packages(),
     install_requires=read_lines("requirements.txt"),
+    extras_require={
+        "dev": [
+            "lenstronomy==1.11.1",
+            "setuptools>=67.2.0",
+        ],
+    },
     keywords = [
         "gravitational lensing",
         "astrophysics",

--- a/test/test_cosmology.py
+++ b/test/test_cosmology.py
@@ -35,6 +35,9 @@ def test_comoving_dist():
 
 def test_to_method_flatlambdacdm():
     cosmo = CausticFlatLambdaCDM()
+    # Make sure private tensors are created on float32 by default
+    assert cosmo._comoving_distance_helper_x_grid.dtype == torch.float32
+    assert cosmo._comoving_distance_helper_y_grid.dtype == torch.float32
     cosmo.to(dtype=torch.float64)
     # Make sure distance helper get sent to proper dtype and device
     assert cosmo._comoving_distance_helper_x_grid.dtype == torch.float64

--- a/test/test_cosmology.py
+++ b/test/test_cosmology.py
@@ -33,5 +33,13 @@ def test_comoving_dist():
         assert np.allclose(vals, vals_ref, rtol, atol)
 
 
+def test_to_method_flatlambdacdm():
+    cosmo = CausticFlatLambdaCDM()
+    cosmo.to(dtype=torch.float64)
+    # Make sure distance helper get sent to proper dtype and device
+    assert cosmo._comoving_distance_helper_x_grid.dtype == torch.float64
+    assert cosmo._comoving_distance_helper_y_grid.dtype == torch.float64
+
+
 if __name__ == "__main__":
     test_comoving_dist()

--- a/test/test_multiplane.py
+++ b/test/test_multiplane.py
@@ -1,4 +1,5 @@
 from math import pi
+from operator import mul
 
 import lenstronomy.Util.param_util as param_util
 import torch
@@ -89,10 +90,17 @@ def test_params():
     params = [torch.randn(pixels, pixels) for i in range(10)]
 
     # Test out the computation of a few quantities to make sure params are passed correctly
+    
+    # First case, params as list of tensors
     kappa_eff = multiplane_lens.effective_convergence_div(x, y, z_s, params)
     assert kappa_eff.shape == torch.Size([32, 32])
     alphax, alphay = multiplane_lens.effective_reduced_deflection_angle(x, y, z_s, params)
 
+    # Test that we can pass a dictionary
+    params = {f"plane_{p}": torch.randn(pixels, pixels) for p in range(n_planes)}
+    kappa_eff = multiplane_lens.effective_convergence_div(x, y, z_s, params)
+    assert kappa_eff.shape == torch.Size([32, 32])
+    alphax, alphay = multiplane_lens.effective_reduced_deflection_angle(x, y, z_s, params)
 
     
 if __name__ == "__main__":

--- a/test/test_multiplane.py
+++ b/test/test_multiplane.py
@@ -96,6 +96,11 @@ def test_params():
     assert kappa_eff.shape == torch.Size([32, 32])
     alphax, alphay = multiplane_lens.effective_reduced_deflection_angle(x, y, z_s, params)
 
+    # Second case, params given as a kwargs 
+    kappa_eff = multiplane_lens.effective_convergence_div(x, y, z_s, params=params)
+    assert kappa_eff.shape == torch.Size([32, 32])
+    alphax, alphay = multiplane_lens.effective_reduced_deflection_angle(x, y, z_s, params=params)
+
     # Test that we can pass a dictionary
     params = {f"plane_{p}": torch.randn(pixels, pixels) for p in range(n_planes)}
     kappa_eff = multiplane_lens.effective_convergence_div(x, y, z_s, params)

--- a/test/test_parameter.py
+++ b/test/test_parameter.py
@@ -28,3 +28,10 @@ def test_shape_error_messages():
         # wrong number of dimensions
         PixelatedConvergence(fov, n_pix, cosmo, shape=(8,))
 
+
+def test_repr():
+    cosmo = FlatLambdaCDM()
+    print(cosmo.h0)
+    assert cosmo.h0.__repr__() == f"Param(value={cosmo.h0.value}, dtype={str(cosmo.h0.dtype)})"
+    cosmo = FlatLambdaCDM(h0=None)
+    assert cosmo.h0.__repr__() == f"Param(shape={cosmo.h0.shape})"


### PR DESCRIPTION
- A minor bug fix in the `Parameter.__repr__` method.
- An important bug fix in `Cosmology.__init__` not sending private tensors `device`.
- An important bug fixed in the `@unpack` decorator not handling the unpacking correctly list or dict `params` passed as an argument or a keyword argument. This issue was found using the `Multiplane` lens, and an appropriate test was created using this object. This issue was missed in previous tests since most of them use the `Simulator` class. The `Simulator.__call__` method does not use the unpack decorator, rather it calls `Parametrized.pack` directly.
- Loosened the requirements file